### PR TITLE
Changed default version to oncotree_latest_stable

### DIFF
--- a/core/src/main/java/org/mskcc/oncotree/utils/VersionUtil.java
+++ b/core/src/main/java/org/mskcc/oncotree/utils/VersionUtil.java
@@ -38,7 +38,7 @@ public class VersionUtil {
 
     public static Version getDefaultVersion() throws InvalidVersionException {
         // note we will throw an InvalidVersionException if this is not found in TopBraid
-        return getVersion("oncotree_current"); 
+        return getVersion("oncotree_latest_stable"); 
     } 
 
 }


### PR DESCRIPTION
Changed the default version to "oncotree_latest_stable" which is an alias for whatever OncoTree version is the latest stable (timestamped) release. 