### PR TITLE
Connected tumor_types.txt api to topbraid

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,10 +16,10 @@
         <artifactId>master</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
         <tomcat.version>7.0.52</tomcat.version>
         <github.global.server>github</github.global.server>
         <spring.version>4.3.8.RELEASE</spring.version>
@@ -159,7 +159,8 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
+            <version>3.4</version>
+            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/core/src/main/java/org/mskcc/oncotree/utils/VersionUtil.java
+++ b/core/src/main/java/org/mskcc/oncotree/utils/VersionUtil.java
@@ -16,6 +16,7 @@ import java.util.List;
 public class VersionUtil {
 
     private static OncoTreeVersionRepository oncoTreeVersionRepository;
+    public static final String DEFAULT_VERSION = "oncotree_latest_stable";
     @Autowired
     public void setOncoTreeVersionRepository(OncoTreeVersionRepository property) { oncoTreeVersionRepository = property; }
 
@@ -38,7 +39,6 @@ public class VersionUtil {
 
     public static Version getDefaultVersion() throws InvalidVersionException {
         // note we will throw an InvalidVersionException if this is not found in TopBraid
-        return getVersion("oncotree_latest_stable"); 
-    } 
-
+        return getVersion(DEFAULT_VERSION);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
         <tomcat.version>7.0.52</tomcat.version>
         <github.global.server>github</github.global.server>
         <spring.version>4.3.8.RELEASE</spring.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -9,15 +9,15 @@
 
     <name>OncoTree Web</name>
     <description>The web module for OncoTree</description>
-    
+
     <parent>
         <groupId>org.mskcc.oncotree</groupId>
         <artifactId>master</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    
+
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
         <github.global.server>github</github.global.server>
         <spring.version>4.3.8.RELEASE</spring.version>
         <spring.boot.version>1.5.3.RELEASE</spring.boot.version>
@@ -44,7 +44,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -71,9 +71,9 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring.boot.version}</version>
         </dependency>
-        
+
         <!--
-        Ensure that the embedded servlet container doesn’t interfere with 
+        Ensure that the embedded servlet container doesn’t interfere with
         the servlet container to which the war file will be deployed.
         Otherwise it may cause Offending class issue.
         http://stackoverflow.com/questions/15601469/jar-not-loaded-see-servlet-spec-2-3-section-9-7-2-offending-class-javax-serv
@@ -98,7 +98,7 @@
             <version>2.2.2</version>
             <scope>compile</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.mskcc.oncotree</groupId>
             <artifactId>core</artifactId>

--- a/web/src/main/java/org/mskcc/oncotree/api/TumorTypesTxtApi.java
+++ b/web/src/main/java/org/mskcc/oncotree/api/TumorTypesTxtApi.java
@@ -15,6 +15,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.mskcc.oncotree.model.TumorType;
+import org.mskcc.oncotree.utils.CacheUtil;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -32,8 +36,13 @@ public class TumorTypesTxtApi {
         produces = {"text/plain"},
         method = RequestMethod.GET)
     public ResponseEntity<InputStreamResource> tumorTypesTxtGet(
+        @ApiParam(value = "The version of tumor types. For example, " + VersionUtil.DEFAULT_VERSION + ". Please see GitHub for released versions. ")
+        @RequestParam(value = "version", required = false) String version
     ) {
-        InputStream inputStream = TumorTypesUtil.getTumorTypeInputStream();
+        Map<String, TumorType> tumorTypes = new HashMap<>();
+        Version v = (version == null) ? VersionUtil.getDefaultVersion() : VersionUtil.getVersion(version);
+        tumorTypes = CacheUtil.getOrResetTumorTypesByVersion(v);
+        InputStream inputStream = TumorTypesUtil.getTumorTypeInputStream(tumorTypes);
         InputStreamResource inputStreamResource = new InputStreamResource(inputStream);
         return new ResponseEntity<>(inputStreamResource, HttpStatus.OK);
     }

--- a/web/src/main/resources/application.properties-EXAMPLE
+++ b/web/src/main/resources/application.properties-EXAMPLE
@@ -2,8 +2,6 @@ springfox.documentation.swagger.v2.path=/api-docs
 
 server.port=${port:38080}
 
-tumor_type_file_path=
-
 # for topbraid e.g. https://evn.mskcc.org/evn/tbl/sparql
 topbraid.url=
 topbraid.username=


### PR DESCRIPTION
Tumor_types.txt endpoint now gets data from topbraid instead of file on filesystem. Response is parsed into a tsv. Front end currently uses the tumot_types.txt api endpoint to render tree visualization, so this connects the front end to topbraid.

Not currently supporting NCI/UMLS fields.

@sheridancbio @mandawilson 