### PR TITLE
Allow front end to properly display versions from api

### DIFF
--- a/web/src/main/resources/static/index.html
+++ b/web/src/main/resources/static/index.html
@@ -19,7 +19,7 @@
       <div class="row">
         <div class="col-lg-6 col-md-8 col-sm-12 col-xs-12">
           <b>CMO Tumor Type Tree</b><br>
-          Please send all comments and suggestions to <a href="mailto:schultz@cbio.mskcc.org?Subject=Oncotree comment" target="_top"><u>schultz@cbio.mskcc.org</u></a><br>
+          Please send all comments and suggestions to <a href="mailto:oncotree@googlegroups.com?Subject=Oncotree comment" target="_top"><u>oncotree@googlegroups.com</u></a><br>
           If you cannot see the tree below in Internet Explorer, please use Firefox or Chrome.
           <br/>
           <span id="summary-info"></span>
@@ -29,8 +29,6 @@
           <span id="other-version">Switch to other versions: 
             <span class="other-version-content"></span> 
             <br/>
-            For more information about different versions, please see 
-            <a href="https://github.com/cBioPortal/oncotree/releases" target="_blank">OncoTree GitHub</a></span>
         </div>
       </div>
       <br/>

--- a/web/src/main/resources/static/js/main.js
+++ b/web/src/main/resources/static/js/main.js
@@ -20,7 +20,7 @@ $(document).ready(function(){
             && data.hasOwnProperty('data')
             && data.data instanceof Array) {
             versions_ = data.data.reduce(function(acc, cur) {
-              acc[cur.version] = cur;
+              acc[cur.api_identifier] = cur;
               return acc;
             }, {});
           }
@@ -91,7 +91,7 @@ $(document).ready(function(){
           _hash += '?version=' + item;
           _content = item;
         }
-        _str.push('<span class="item" hash="' + _hash + '">' + _content + '</span>');
+        _str.push('<span title="' + versions_[item].description + '" ' + 'class="item" hash="' + _hash + '">' + _content + '</span>');
       });
       $('#other-version .other-version-content').html(_str.join(''));
       $('#other-version .other-version-content .item').click(function() {


### PR DESCRIPTION
Properly display the versions on the front end. Added tooltip text that displays the description.
Changed the email from Niki's email to the google groups.

Signed-off-by: zheins <zackheins@gmail.com>

@sheridancbio @zhx828 