### PR TITLE
Connect mainTypes endpoint to topbraid

### DIFF
--- a/core/src/main/java/org/mskcc/oncotree/model/MainType.java
+++ b/core/src/main/java/org/mskcc/oncotree/model/MainType.java
@@ -16,11 +16,16 @@ import java.util.Objects;
 @ApiModel(description = "General tumor type category.")
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.SpringMVCServerCodegen", date = "2016-04-04T17:16:11.368Z")
 public class MainType  {
-  
+
   private Integer id = null;
   private String name = null;
 
-  
+  public MainType(){}
+
+  public MainType(String name) {
+      this.name = name;
+  }
+
   /**
    * the numarical identifier of tumor type.
    **/
@@ -33,7 +38,7 @@ public class MainType  {
     this.id = id;
   }
 
-  
+
   /**
    * Tumor type name.
    **/
@@ -46,7 +51,7 @@ public class MainType  {
     this.name = name;
   }
 
-  
+
 
   @Override
   public boolean equals(Object o) {
@@ -70,7 +75,7 @@ public class MainType  {
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class MainType {\n");
-    
+
     sb.append("  id: ").append(id).append("\n");
     sb.append("  name: ").append(name).append("\n");
     sb.append("}\n");

--- a/core/src/main/java/org/mskcc/oncotree/utils/CacheUtil.java
+++ b/core/src/main/java/org/mskcc/oncotree/utils/CacheUtil.java
@@ -5,10 +5,7 @@ import org.mskcc.oncotree.model.MainType;
 import org.mskcc.oncotree.model.TumorType;
 import org.mskcc.oncotree.model.Version;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by Hongxin on 2/25/16.
@@ -46,12 +43,10 @@ public class CacheUtil {
     }
 
     public static List<MainType> getMainTypesByVersion(Version version) throws InvalidOncoTreeDataException {
-        if (mainTypes.containsKey(version)) {
-            return mainTypes.get(version);
-        } else {
+        if (!mainTypes.containsKey(version)) {
             mainTypes.put(version, new ArrayList<MainType>());
-            return mainTypes.get(version);
         }
+        return mainTypes.get(version);
     }
 
     public static void addMainTypeByVersion(Version version, MainType mainType) {
@@ -80,5 +75,4 @@ public class CacheUtil {
         }
         return null;
     }
-
 }

--- a/core/src/main/java/org/mskcc/oncotree/utils/MainTypesUtil.java
+++ b/core/src/main/java/org/mskcc/oncotree/utils/MainTypesUtil.java
@@ -1,35 +1,43 @@
 package org.mskcc.oncotree.utils;
 
+import com.google.common.collect.Lists;
 import org.mskcc.oncotree.error.InvalidOncoTreeDataException;
 import org.mskcc.oncotree.model.MainType;
 import org.mskcc.oncotree.model.Version;
 
-import java.util.List;
+import java.util.*;
+import org.mskcc.oncotree.model.TumorType;
 
 /**
  * Created by Hongxin on 2/25/16.
  */
 public class MainTypesUtil {
-    /**
-     * return MainType if not exist, create a new one.
-     *
-     * @param name The searched main type name
-     * @return
-     */
-    public static MainType getOrCreateMainType(String name, Version version) throws InvalidOncoTreeDataException {
-        List<MainType> mainTypes = CacheUtil.getMainTypesByVersion(version);
 
-        for (MainType mainType : mainTypes) {
-            if (mainType.getName().equalsIgnoreCase(name)) {
-                return mainType;
+    public static List<MainType> getMainTypesByTumorTypes(Map<String, TumorType> tumorTypes) {
+        Set<MainType> mainTypes = new HashSet<>();
+        // skip the root node, "TISSUE". Just add it's children
+        for (String tumorTypeName : tumorTypes.keySet()) {
+            TumorType tumorType = tumorTypes.get(tumorTypeName);
+            Map<String, TumorType> children = tumorType.getChildren();
+            for (String code : children.keySet()) {
+                addMainTypesToSet(children.get(code), mainTypes);
             }
         }
+        List<MainType> toReturn = new ArrayList<>();
+        toReturn.addAll(mainTypes);
+        return toReturn;
+    }
 
-        MainType mainType = new MainType();
-        mainType.setName(name);
-        mainType.setId(mainTypes.size());
-
-        CacheUtil.addMainTypeByVersion(version, mainType);
-        return mainType;
+    private static void addMainTypesToSet(TumorType tumorType, Set<MainType> mainTypes) {
+        if (tumorType.getMainType() != null) {
+            mainTypes.add(tumorType.getMainType());
+        }
+        Map<String, TumorType> children = tumorType.getChildren();
+        if (children.size() > 0) {
+            for (String code : children.keySet()) {
+                TumorType child = children.get(code);
+                addMainTypesToSet(child, mainTypes);
+            }
+        }
     }
 }

--- a/core/src/main/java/org/mskcc/oncotree/utils/TumorTypesUtil.java
+++ b/core/src/main/java/org/mskcc/oncotree/utils/TumorTypesUtil.java
@@ -117,7 +117,7 @@ public class TumorTypesUtil {
     private static void addTumorTypeToRows(TumorType tumorType, List<String> rows, List<String> parents) {
         List<String> row = new ArrayList<>();
         String oncotreeCode = StringUtils.defaultString(tumorType.getCode()).trim();
-        
+
         // if parents.size() > 4 at this point, this means that the oncotree cannot be represented in our expected format as there are
         // only 5 levels of headers. Abort the attemp to render the spreadsheet and throw an exception.
         if (parents.size() > 4) {
@@ -272,7 +272,7 @@ public class TumorTypesUtil {
         // we do not have level or tissue
         TumorType tumorType = new TumorType();
         if (oncoTreeNode.getMainType() != null) {
-            tumorType.setMainType(MainTypesUtil.getOrCreateMainType(oncoTreeNode.getMainType(), version));
+            tumorType.setMainType(new MainType(oncoTreeNode.getMainType()));
         }
         tumorType.setCode(oncoTreeNode.getCode());
         tumorType.setName(oncoTreeNode.getName());

--- a/web/src/main/java/org/mskcc/oncotree/api/MainTypesApi.java
+++ b/web/src/main/java/org/mskcc/oncotree/api/MainTypesApi.java
@@ -4,16 +4,19 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponses;
+import java.util.HashMap;
+import java.util.Map;
 import org.mskcc.oncotree.model.MainTypeResp;
 import org.mskcc.oncotree.model.MainTypesResp;
 import org.mskcc.oncotree.model.Meta;
+import org.mskcc.oncotree.model.TumorType;
 import org.mskcc.oncotree.model.Version;
 import org.mskcc.oncotree.utils.CacheUtil;
+import org.mskcc.oncotree.utils.MainTypesUtil;
 import org.mskcc.oncotree.utils.VersionUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,7 +37,7 @@ public class MainTypesApi {
         produces = {"application/json"},
         method = RequestMethod.GET)
     public ResponseEntity<MainTypesResp> mainTypesGet(
-        @ApiParam(value = "The version of tumor types. For example, 1, 1.1 Please see GitHub for released versions.")
+        @ApiParam(value = "The version of tumor types. For example, " + VersionUtil.DEFAULT_VERSION  + ". Please see the versions api documentation for released versions.")
         @RequestParam(value = "version", required = false) String version
 //        , @ApiParam(value = "The callback function name. This has to be used with dataType JSONP.")
 //        @RequestParam(value = "callback", required = false) String callback
@@ -46,49 +49,11 @@ public class MainTypesApi {
         meta.setCode(200);
         resp.setMeta(meta);
 
+        Map<String, TumorType> tumorTypes = new HashMap<>();
         Version v = (version == null) ? VersionUtil.getDefaultVersion() : VersionUtil.getVersion(version);
-        resp.setData(CacheUtil.getMainTypesByVersion(v));
+        tumorTypes = CacheUtil.getOrResetTumorTypesByVersion(v);
+        resp.setData(MainTypesUtil.getMainTypesByTumorTypes(tumorTypes));
 
         return new ResponseEntity<MainTypesResp>(resp, HttpStatus.OK);
     }
-
-
-    @ApiOperation(value = "Get main type by using numerical unique ID", notes = "", response = MainTypeResp.class)
-    @ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = 200, message = "OK")})
-    @RequestMapping(value = "/{id}",
-        produces = {"application/json"},
-        method = RequestMethod.GET)
-    public ResponseEntity<MainTypeResp> mainTypesIdGet(
-        @ApiParam(value = "The numerical ID of the desired tumor type", required = true) @PathVariable("id") Integer id,
-        @ApiParam(value = "The version of tumor types. For example, 1, 1.1 Please see GitHub for released versions.")
-        @RequestParam(value = "version", required = false) String version
-//        , @ApiParam(value = "The callback function name. This has to be used with dataType JSONP.") @RequestParam(value = "callback", required = false) String callback
-    )
-        throws NotFoundException {
-        MainTypeResp resp = new MainTypeResp();
-
-        HttpStatus httpStatus = HttpStatus.OK;
-
-        Meta meta = new Meta();
-        meta.setCode(200);
-        resp.setMeta(meta);
-
-        if (id != null) {
-            Version v = (version == null) ? VersionUtil.getDefaultVersion() : VersionUtil.getVersion(version);
-
-            // Cache in tumor types in case no data present
-            CacheUtil.getOrResetTumorTypesByVersion(v);
-
-            resp.setData(CacheUtil.getMainTypeByVersion(v, id));
-        } else {
-            httpStatus = HttpStatus.BAD_REQUEST;
-            meta.setCode(httpStatus.value());
-            meta.setErroMessage("Please use integer number for the id parameter");
-        }
-
-        return new ResponseEntity<MainTypeResp>(resp, httpStatus);
-    }
-
-
 }

--- a/web/src/main/java/org/mskcc/oncotree/api/TumorTypesApi.java
+++ b/web/src/main/java/org/mskcc/oncotree/api/TumorTypesApi.java
@@ -72,7 +72,7 @@ public class TumorTypesApi {
         produces = {"application/json"},
         method = RequestMethod.GET)
     public ResponseEntity<InlineResponse200> tumorTypesGet(
-        @ApiParam(value = "The version of tumor types. For example, 1, 1.1 Please see GitHub for released versions. ")
+        @ApiParam(value = "The version of tumor types. For example, " + VersionUtil.DEFAULT_VERSION + ". Please see the versions api documentation for released versions.")
         @RequestParam(value = "version", required = false) String version,
         @ApiParam(value = "The flat list of tumor types", defaultValue = "false")
         @RequestParam(value = "flat", required = false, defaultValue = "false") Boolean flat,
@@ -90,9 +90,9 @@ public class TumorTypesApi {
         Map<String, TumorType> tumorTypes = new HashMap<>();
 
         Version v = (version == null) ? VersionUtil.getDefaultVersion() : VersionUtil.getVersion(version);
-        
+
         tumorTypes = CacheUtil.getOrResetTumorTypesByVersion(v);
-        
+
         if (flat) {
             response200.setData(TumorTypesUtil.flattenTumorTypes(tumorTypes, null));
         } else {
@@ -163,7 +163,7 @@ public class TumorTypesApi {
 
         // Cache in tumor types in case no data present
         CacheUtil.getOrResetTumorTypesByVersion(v);
-        
+
         for (TumorTypeQuery query : queries.getQueries()) {
             List<TumorType> matchedTumorTypes = new ArrayList<>();
             matchedTumorTypes = v == null ? new ArrayList<TumorType>() : TumorTypesUtil.findTumorTypesByVersion(query.getType(), query.getQuery(), query.getExactMatch(), v, false);
@@ -210,10 +210,10 @@ public class TumorTypesApi {
         throws NotFoundException {
         List<TumorType> matchedTumorTypes = new ArrayList<>();
         Version v = (version == null) ? VersionUtil.getDefaultVersion() : VersionUtil.getVersion(version);
-        
+
         // Cache in tumor types in case no data present
         CacheUtil.getOrResetTumorTypesByVersion(v);
-        
+
         matchedTumorTypes = v == null ? new ArrayList<TumorType>() : TumorTypesUtil.findTumorTypesByVersion(type, query, exactMatch, v, false);
         SearchTumorTypesResp resp = new SearchTumorTypesResp();
 

--- a/web/src/main/java/org/mskcc/oncotree/api/TumorTypesTxtApi.java
+++ b/web/src/main/java/org/mskcc/oncotree/api/TumorTypesTxtApi.java
@@ -36,7 +36,7 @@ public class TumorTypesTxtApi {
         produces = {"text/plain"},
         method = RequestMethod.GET)
     public ResponseEntity<InputStreamResource> tumorTypesTxtGet(
-        @ApiParam(value = "The version of tumor types. For example, " + VersionUtil.DEFAULT_VERSION + ". Please see GitHub for released versions. ")
+        @ApiParam(value = "The version of tumor types. For example, " + VersionUtil.DEFAULT_VERSION + ". Please see the versions api documentation for released versions.")
         @RequestParam(value = "version", required = false) String version
     ) {
         Map<String, TumorType> tumorTypes = new HashMap<>();


### PR DESCRIPTION
Connects the mainTypes endpoint to topbraid using the tumorTypesUtil class. MainTypes are populated from the same oncotree response by just going through all nodes and adding them to a set of MainTypes.

Confirmed from @zhx828 that the /api/mainTypes/{id} endpoint is not needed.

Signed-off-by: zheins <zackheins@gmail.com>