### PR TITLE
Fixed memory leak

### DIFF
--- a/core/src/main/java/org/mskcc/oncotree/model/Version.java
+++ b/core/src/main/java/org/mskcc/oncotree/model/Version.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Objects;
 
 /**
  * Created by Hongxin on 5/23/16.
@@ -83,6 +84,26 @@ public class Version {
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Version otherVersion = (Version) o;
+        return Objects.equals(version, otherVersion.version) &&
+            Objects.equals(description, otherVersion.description) &&
+            Objects.equals(graphURI, otherVersion.graphURI) &&
+            Objects.equals(visible, otherVersion.visible);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, description, graphURI, visible);
     }
 
 }

--- a/core/src/main/java/org/mskcc/oncotree/utils/CacheUtil.java
+++ b/core/src/main/java/org/mskcc/oncotree/utils/CacheUtil.java
@@ -5,12 +5,18 @@ import org.mskcc.oncotree.model.MainType;
 import org.mskcc.oncotree.model.TumorType;
 import org.mskcc.oncotree.model.Version;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.*;
 
 /**
  * Created by Hongxin on 2/25/16.
  */
 public class CacheUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(CacheUtil.class);
+
     public static Map<Version, List<MainType>> mainTypes = new HashMap<>();
     public static Map<Version, Map<String, TumorType>> tumorTypes = new HashMap<>();
 
@@ -34,9 +40,17 @@ public class CacheUtil {
     }
 
     public static Map<String, TumorType> getTumorTypesByVersion(Version version) throws InvalidOncoTreeDataException {
+        logger.debug("getTumorTypesByVersion() -- looking for version '" + version.getVersion() + "' in cache");
+        if (logger.isDebugEnabled()) {
+            for (Version cachedVersion : tumorTypes.keySet()) {
+                logger.debug("getTumorTypesByVersion() -- tumorTypes cache contains '" + cachedVersion.getVersion() + "'");
+             }
+        }
         if (tumorTypes.containsKey(version)) {
+            logger.debug("getTumorTypesByVersion() -- found '" + version.getVersion() + "' in cache");
             return tumorTypes.get(version);
         } else {
+            logger.debug("getTumorTypesByVersion() -- did NOT find '" + version.getVersion() + "' in cache, getting now");
             tumorTypes.put(version, TumorTypesUtil.getTumorTypesByVersionFromRaw(version));
             return tumorTypes.get(version);
         }


### PR DESCRIPTION
The Version object is never found in the cache, and so we always get the tumor types from the repository, and then store it in the cache - so the cache was getting bigger with every single request to the website.  I did some logging and confirmed this is true, I refreshed a five of times, and ended up with five 'oncotree_development' Version objects in the cache.  It is because Version didn't have equals and hashCode overridden, and Version (instead of a String version) was the key).

Fix is here.