### PR TITLE
add back older oncotree versions to dropdown

### DIFF
--- a/web/src/main/resources/static/index.html
+++ b/web/src/main/resources/static/index.html
@@ -50,14 +50,12 @@
                 If you cannot see the tree below in Internet Explorer, please use Firefox or Chrome.
               </p>
               <div class="alert alert-info" role="alert">
-                <p>
-                  <span>OncoTree verison currently displayed: </span>
-                  <span id="other-version">
-                    <select class="other-version-content"></select>
-                  </span>
-                </p>
-                <p><span id="summary-info"></span></p>
-                <p><span id='version-note'></span></p>
+                <span>Currently displaying : </span>
+                <span id="other-version">
+                  <select class="other-version-content"></select>
+                </span>
+                <div><span id="oncotree-version-statistics"></span></div>
+                <div><span id='oncotree-version-note'></span></div>
               </div>
             </div>
           </div>
@@ -85,8 +83,12 @@
           </div>
           <div id="tree-div"></div>
           <div id="summary-duplicates" class="col-lg-6 col-md-8 col-sm-12 col-xs-12">
-            <b>Acronym crash:</b>
-            <p id="" class="bg-danger"></p>
+            <div class="alert alert-warning alert-dismissible fade show" role="alert">
+              <strong>Oncotree Definitions Not Yet Available.</strong> The definitions containing the oncotree nodes, annotations, and relationships have not yet been loaded. This information is normally immediately available for display, but sometimes after a web server restart it can take up to 3 minutes for the data to be organized in the webserver. If you are seeing this message for longer than that, then a more serious problem is preventing the oncotree website from functioning properly and we apologize for the inconvenience this causes.
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
           </div>
           <span id="top-link-block" class="hidden">
             <a href="#top" class="well well-sm"  onclick="$('html,body').animate({scrollTop:0, scrollLeft: 0},'slow');return false;">

--- a/web/src/main/resources/static/js/tree.js
+++ b/web/src/main/resources/static/js/tree.js
@@ -32,7 +32,7 @@ var tree = (function () {
 
     function UniqueTreeNodeDatum() {
         this.name = '';
-        this.acronym = '';
+        this.code = '';
         this.mainType = '';
         this.color = '';
         this.nci = [];
@@ -58,7 +58,7 @@ var tree = (function () {
         // childData is always for a new unique node
         var childNode = new UniqueTreeNodeDatum();
         childNode.name = childData.name + " (" + childData.code + ")";
-        childNode.acronym = childData.code;
+        childNode.code = childData.code;
 
         if (childData.hasOwnProperty('mainType') && childData.mainType != null && childData.mainType !== '') {
             childNode.mainType = childData.mainType;
@@ -84,10 +84,10 @@ var tree = (function () {
         }
 
         // save code and name to check for duplicate codes later
-        if (!oncotreeCodesToNames.hasOwnProperty(childNode.acronym)) {
-            oncotreeCodesToNames[childNode.acronym] = [];
+        if (!oncotreeCodesToNames.hasOwnProperty(childNode.code)) {
+            oncotreeCodesToNames[childNode.code] = [];
         }
-        oncotreeCodesToNames[childNode.acronym].push(childNode.name);
+        oncotreeCodesToNames[childNode.code].push(childNode.name);
 
         // add new node to children list of parentNode
         parentNode.children.push(childNode);
@@ -149,7 +149,7 @@ var tree = (function () {
             } else {
                 $('#summary-duplicates').css('display', 'none');
             }
-            $("#summary-info").text(function () {
+            $("#oncotree-version-statistics").text(function () {
                 return "Includes " + numOfTumorTypes + " tumor type" + ( numOfTumorTypes === 1 ? "" : "s" ) + " from " + numOfTissues + " tissue" + ( numOfTissues === 1 ? "" : "s" ) + ".";
             });
         });
@@ -171,13 +171,6 @@ var tree = (function () {
         root.y0 = 0;
         // Initialize the display to show a few nodes.
         root.children.forEach(toggleAll);
-        // toggle(root.children[1]);
-        // toggle(root.children[2]);
-        // toggle(root.children[5]);
-        // toggle(root.children[5].children[0]);
-        // toggle(root.children[8]);
-        // toggle(root.children[8].children[0]);
-        // toggle(root.children[15]);
         update(root);
         numOfTissues = root.children.length;
         root.children.forEach(searchLeaf);
@@ -342,14 +335,14 @@ var tree = (function () {
                     umls_links.push(getUMLSLink(""));
                 }
 
-                _qtipContent += '<b>Code:</b> ' + d.acronym +
+                _qtipContent += '<b>Code:</b> ' + d.code +
 
                      //clipboard JS is not supported in Safari.
                     ((is_safari && !is_chrome) ?
                         '<button style="margin-left: 5px;" class="btn btn-light btn-sm" ' +
                         ' disabled>"Copy" is not available in Safari</button>' :
                         '<button style="margin-left: 5px;" class="clipboard-copy btn btn-light btn-sm" ' +
-                        'data-clipboard-text="' + d.acronym + '"  ' +
+                        'data-clipboard-text="' + d.code + '"  ' +
                         '>Copy</button>'
                     ) +
                     '<br/>';


### PR DESCRIPTION
- older versions added after disabled divider
- versions sorted .. where "visible" attribute now promotes the version to the "above the line" group
- otherwise, versions sorted in reverse chronological order
- cleanup of older code (dropping of dead code) and renaming of variables
- now when entering page, the "selected" attribute of the select options are set according to the html "version" property (or default)

Co-authored-by: Manda Wilson <1458628+mandawilson@users.noreply.github.com>