### PR TITLE
update sparql queries to work with new TopBraid Oncotree namespace

### DIFF
--- a/core/src/main/java/org/mskcc/oncotree/topbraid/OncoTreeRepository.java
+++ b/core/src/main/java/org/mskcc/oncotree/topbraid/OncoTreeRepository.java
@@ -38,7 +38,7 @@ public class OncoTreeRepository extends TopBraidRepository<OncoTreeNode> {
     private static final Logger logger = LoggerFactory.getLogger(OncoTreeRepository.class);
 
     private String query = "PREFIX skos:<http://www.w3.org/2004/02/skos/core#> " +
-        "PREFIX onc:<http://data.mskcc.org/ontologies/oncotree/> " +
+        "PREFIX onc:<http://data.mskcc.org/ontologies/oncotree#> " +
         "SELECT DISTINCT (?s AS ?uri) ?code ?name ?mainType ?color ?parentCode ?revocations ?precursors " +
         "WHERE { " +
         "   GRAPH <%s> { " +

--- a/scripts/validate_topbraid_uris.py
+++ b/scripts/validate_topbraid_uris.py
@@ -32,7 +32,7 @@ PREFIX oncotree-version:<http://data.mskcc.org/ontologies/oncotree_version/>
 
 TOPBRAID_DATA_QUERY = """
 PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
-        PREFIX onc:<http://data.mskcc.org/ontologies/oncotree/>
+        PREFIX onc:<http://data.mskcc.org/ontologies/oncotree#>
 SELECT DISTINCT (?s AS ?uri) ?code ?name ?mainType ?color ?parentCode ?revocations ?precursors
         WHERE {
            GRAPH <%s> {


### PR DESCRIPTION
new TopBraid version has ontologies denoted with `#` sign. 
can run query here: http://evn.mskcc.org/edg/tbl/sparql

Without the change, properties such as maintype and color will come back blank.