### PR TITLE
adjust homepage to count all nodes

### DIFF
--- a/web/src/main/resources/static/js/tree.js
+++ b/web/src/main/resources/static/js/tree.js
@@ -13,7 +13,7 @@ var tree = (function () {
         fontSize = '12px',
         root;
 
-    var tree, diagonal, vis, numOfTumorTypes = 0, numOfTissues = 0;
+    var tree, diagonal, vis, numOfTumorTypes = 0, numOfTumorTypeLeaves = 0, numOfTumorTypeParents = 0, numOfTissues = 0;
 
     var oncotreeCodesToNames = {}; // used to find duplicate codes
 
@@ -640,6 +640,8 @@ var tree = (function () {
     function searchLeaf(node) {
         var i, length;
         if (node._children || node.children) {
+            numOfTumorTypes++;
+            numOfTumorTypeParents++;
             if (node.children) {
                 length =  node.children.length;
                 for (i = 0; i < length; i++) {
@@ -654,6 +656,7 @@ var tree = (function () {
             }
         } else {
             numOfTumorTypes++;
+            numOfTumorTypeLeaves++;
         }
     }
 


### PR DESCRIPTION
Previously, only leaf nodes of the tree were counted in the total count
of tumor types displayed on the home page.Now all nodes in the tree except
for the root node (TISSUE) are counted in the total.

Co-authored-by: Avery Wang <18199796+averyniceday@users.noreply.github.com>
Co-authored-by: Robert Sheridan <7747489+sheridancbio@users.noreply.github.com>