### PR TITLE
add check of maven build step to integration test

### DIFF
--- a/integration-tests/test-oncotree-dependent-tools.sh
+++ b/integration-tests/test-oncotree-dependent-tools.sh
@@ -76,7 +76,12 @@ function find_free_port {
 rsync $JENKINS_PROPERTIES_DIRECTORY/oncotree/$JENKINS_TEST_APPLICATION_PROPERTIES $ONCOTREE_DIRECTORY/web/src/main/resources/$APPLICATION_PROPERTIES
 rsync $JENKINS_PROPERTIES_DIRECTORY/oncotree/log4j.properties $ONCOTREE_DIRECTORY/web/src/main/resources
 rsync $JENKINS_PROPERTIES_DIRECTORY/oncotree/$TEST_APPLICATION_PROPERTIES $ONCOTREE_DIRECTORY/core/src/test/resources/$APPLICATION_PROPERTIES
-cd $ONCOTREE_DIRECTORY ; mvn package -Dpackaging.type=jar
+cd $ONCOTREE_DIRECTORY
+mvn clean install -Dpackaging.type=jar
+if [ $? -gt 0 ] ; then
+    echo "Build of ONCOTREE source code failed - integration tests cannot be run."
+    exit 1
+fi
 
 #start up ONCOTREE on some port on dashi-dev
 ONCOTREE_PORT=`find_free_port`


### PR DESCRIPTION
This change was done to fix a clash between two jenkins jobs --- one which tests the mvn build step (oncotree), and one which performs the maven build and deploys an oncotree server and runs various integration tests on clients. We don't need both ... the oncotree job is redundant. And they clash with each other when jenkins runs them at the same time. [also, ehcache usage can collide]. So this PR adds a check of the mvn build step in the integration test and exits with failure if the build fails. Then only 1 jenkins job needs to be run.