### PR TITLE
Bulk update graphite

### DIFF
--- a/scripts/graphite.py
+++ b/scripts/graphite.py
@@ -1,0 +1,110 @@
+# Module generate_rdf.py
+
+import uuid
+import sys # TODO remove
+
+CSV_LABEL = "Primary Concept"
+CSV_RESOURCE_URI = "Resource URI"
+CSV_ONCOTREE_CODE = "notation (SKOS)"
+CSV_SCHEME_URI = "skos:inScheme URI"
+CSV_STATUS = "Status"   
+CSV_INTERNAL_ID = "clinicalCasesSubset (OncoTree Tumor Type)"
+CSV_COLOR = "color (OncoTree Tumor Type)"
+CSV_MAIN_TYPE = "mainType (OncoTree Tumor Type)"
+CSV_PRECURSORS = "precursors (OncoTree Tumor Type)"
+CSV_PREFERRED_LABEL = "preferred label (SKOS)"
+CSV_REVOCATIONS = "revocations (OncoTree Tumor Type)"
+CSV_PARENT_RESOURCE_URI = "has broader (SKOS) URI"
+CSV_PARENT_LABEL = "has broader (SKOS)"
+CSV_PARENT_ONCOTREE_CODE = "parent oncotree code"
+
+RDF_HEADER = """<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:ottt="http://data.mskcc.org/ontologies/oncotree#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:graphite="http://schema.synaptica.com/oasis#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:rdf4j="http://rdf4j.org/schema/rdf4j#"
+    xmlns:sesame="http://www.openrdf.org/schema/sesame#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions#">
+"""
+RDF_FOOTER = "</rdf:RDF>"
+RESOURCE_URI_BASE = "https://data.mskcc.org/ontologies/oncotree#"
+RDF_RECORD_FIXED_FIELDS = """\t<rdf:type rdf:resource="http://schema.synaptica.com/oasis#Concept"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:inScheme rdf:resource="https://preprod3.msk.synaptica.net/concept_scheme/b4b33e88-6dcd-5c88-375b-25d629e822f6"/>
+	<graphite:hasTemplate rdf:resource="https://preprod3.msk.synaptica.net/template/fe5efc47-d308-4415-a834-525f5fb792c3"/>
+	<graphite:conceptStatus>Published</graphite:conceptStatus>"""
+
+def write_header(out_file):
+    print(RDF_HEADER, file=out_file)
+
+#<rdf:Description rdf:about="https://data.mskcc.org/ontologies/oncotree#dca88347-5939-4c23-8a19-e4a1db414240">
+#    <rdf:type rdf:resource="http://schema.synaptica.com/oasis#Concept"/>
+#    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+#    <rdfs:label xml:lang="en">T-Lymphoblastic Leukemia/Lymphoma</rdfs:label>
+#    <skos:inScheme rdf:resource="https://preprod3.msk.synaptica.net/concept_scheme/b4b33e88-6dcd-5c88-375b-25d629e822f6"/>
+#    <graphite:hasTemplate rdf:resource="https://preprod3.msk.synaptica.net/template/fe5efc47-d308-4415-a834-525f5fb792c3"/>
+#    <graphite:conceptStatus>Published</graphite:conceptStatus>
+#    <skos:prefLabel xml:lang="en">T-Lymphoblastic Leukemia/Lymphoma</skos:prefLabel>
+#    <skos:notation xml:lang="en">TLL</skos:notation> 
+#    <ottt:color xml:lang="en">LimeGreen</ottt:color>
+#    <ottt:maintype xml:lang="en">T-Lymphoblastic Leukemia/Lymphoma</ottt:maintype>
+#    <ottt:precursors xml:lang="en">ONC000041</ottt:precursors>
+#    <ottt:revocations xml:lang="en">ONC000038</ottt:revocations>
+#    <ottt:clinicalcasessubset xml:lang="en">ONC000744</ottt:clinicalcasessubset>
+#    <skos:broader rdf:resource="https://data.mskcc.org/ontologies/oncotree#35233f33-9d05-42fb-8d0e-4823dcc3a2a2"/>
+#</rdf:Description>
+
+def generate_resource_uri():
+    """Generates a new resource uri"""
+    return RESOURCE_URI_BASE + str(uuid.uuid4())
+
+def write_records(oncotree, oncotree_code_to_resource_uris, out_file):
+    for row in oncotree.values():
+        print(f"<rdf:Description rdf:about=\"{row[CSV_RESOURCE_URI]}\">", file=out_file)
+        print(RDF_RECORD_FIXED_FIELDS, file=out_file)
+        print(f"	<rdfs:label xml:lang=\"en\">{row[CSV_LABEL]}</rdfs:label>", file=out_file)
+        print(f"    <skos:prefLabel xml:lang=\"en\">{row[CSV_PREFERRED_LABEL]}</skos:prefLabel>", file=out_file)
+        print(f"    <skos:notation xml:lang=\"en\">{row[CSV_ONCOTREE_CODE]}</skos:notation>", file=out_file)
+        if row[CSV_COLOR]:
+            print(f"    <ottt:color xml:lang=\"en\">{row[CSV_COLOR]}</ottt:color>", file=out_file)
+        if row[CSV_MAIN_TYPE]:
+            print(f"    <ottt:maintype xml:lang=\"en\">{row[CSV_MAIN_TYPE]}</ottt:maintype>", file=out_file)
+        if row[CSV_PRECURSORS]:
+            print(f"    <ottt:precursors xml:lang=\"en\">{row[CSV_PRECURSORS]}</ottt:precursors>", file=out_file)
+        if row[CSV_REVOCATIONS]:
+            print(f"    <ottt:revocations xml:lang=\"en\">{row[CSV_REVOCATIONS]}</ottt:revocations>", file=out_file)
+        print(f"    <ottt:clinicalcasessubset xml:lang=\"en\">{row[CSV_INTERNAL_ID]}</ottt:clinicalcasessubset>", file=out_file)
+        if row[CSV_ONCOTREE_CODE] == "TISSUE":
+            print(f"	<skos:topConceptOf rdf:resource=\"https://preprod3.msk.synaptica.net/concept_scheme/b4b33e88-6dcd-5c88-375b-25d629e822f6\"/>", file=out_file) 
+        else:
+            parent_resource_uri = row[CSV_PARENT_RESOURCE_URI] if row[CSV_PARENT_RESOURCE_URI] else oncotree_code_to_resource_uris[row[CSV_PARENT_ONCOTREE_CODE]]
+            print(f"    <skos:broader rdf:resource=\"{parent_resource_uri}\"/>", file=out_file)
+        print("</rdf:Description>\n", file=out_file)
+
+def write_footer(out_file):
+    print(RDF_FOOTER, file=out_file)
+
+def get_oncotree_code_to_resource_uris(oncotree):
+    oncotree_code_to_resource_uris = {}
+    for row in oncotree.values():
+        oncotree_code_to_resource_uris[row[CSV_ONCOTREE_CODE]] = row[CSV_RESOURCE_URI]
+    return oncotree_code_to_resource_uris
+
+def populate_all_resource_uris(oncotree):
+    for row in oncotree.values():
+        if not row[CSV_RESOURCE_URI]:
+            row[CSV_RESOURCE_URI] = generate_resource_uri()
+
+def write_rdf(oncotree, out_filename):
+    """Write an RDF to a file"""
+    populate_all_resource_uris(oncotree) # this fills in the empty resource uris with new ones (these should be new records)
+    oncotree_code_to_resource_uris = get_oncotree_code_to_resource_uris(oncotree)
+    with open(out_filename, "w") as out_file:
+        write_header(out_file)
+        write_records(oncotree, oncotree_code_to_resource_uris, out_file)
+        write_footer(out_file)

--- a/scripts/graphite.py
+++ b/scripts/graphite.py
@@ -1,7 +1,20 @@
-# Module generate_rdf.py
+# Copyright (c) 2025 Memorial Sloan-Kettering Cancer Center.                   
+#                                                                              
+# This library is distributed in the hope that it will be useful, but          
+# WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF                   
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  The software and       
+# documentation provided hereunder is on an "as is" basis, and                 
+# Memorial Sloan-Kettering Cancer Center                                       
+# has no obligations to provide maintenance, support,                          
+# updates, enhancements or modifications.  In no event shall                   
+# Memorial Sloan-Kettering Cancer Center                                       
+# be liable to any party for direct, indirect, special,                        
+# incidental or consequential damages, including lost profits, arising         
+# out of the use of this software and its documentation, even if               
+# Memorial Sloan-Kettering Cancer Center                                       
+# has been advised of the possibility of such damage. 
 
 import uuid
-import sys # TODO remove
 
 CSV_LABEL = "Primary Concept"
 CSV_RESOURCE_URI = "Resource URI"

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -30,41 +30,44 @@ import sys
 
 GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL = "https://raw.githubusercontent.com/cBioPortal/oncotree/refs/heads/master/resources/resource_uri_to_oncocode_mapping.txt"
 HELP_FOR_FILE_FORMAT = "In the Graphite 'Concept Manager' left sidebar 'Hierarchy' tab, select your oncotree version, then click on the 'Export' tab in the main panel.  For 'File Format' select 'CSV (Dynamic Property Columns)'. In the 'Include' section uncheck everything except 'Non-primary concept URI' and 'Status'.  In the 'Select Properties to Export' all fields in both 'OncoTree Tumor Type' and 'SKOS' should be selected."
-EXPECTED_HEADER = [graphite.CSV_RESOURCE_URI, \
-    graphite.CSV_LABEL, \
-    graphite.CSV_SCHEME_URI, \
-    graphite.CSV_STATUS, \
-    graphite.CSV_INTERNAL_ID, \
-    graphite.CSV_COLOR, \
-    graphite.CSV_MAIN_TYPE, \
-    graphite.CSV_ONCOTREE_CODE, \
-    graphite.CSV_PRECURSORS, \
-    graphite.CSV_PREFERRED_LABEL, \
-    graphite.CSV_REVOCATIONS, \
-    graphite.CSV_PARENT_RESOURCE_URI, \
+EXPECTED_HEADER = [graphite.CSV_RESOURCE_URI,
+    graphite.CSV_LABEL,
+    graphite.CSV_SCHEME_URI,
+    graphite.CSV_STATUS,
+    graphite.CSV_INTERNAL_ID,
+    graphite.CSV_COLOR,
+    graphite.CSV_MAIN_TYPE,
+    graphite.CSV_ONCOTREE_CODE,
+    graphite.CSV_PRECURSORS,
+    graphite.CSV_PREFERRED_LABEL,
+    graphite.CSV_REVOCATIONS,
+    graphite.CSV_PARENT_RESOURCE_URI,
     graphite.CSV_PARENT_LABEL]
 EXPECTED_HEADER_MODIFIED_FILE = EXPECTED_HEADER + [graphite.CSV_PARENT_ONCOTREE_CODE]
-REQUIRED_FIELDS = [graphite.CSV_LABEL, \
-    graphite.CSV_SCHEME_URI, \
-    graphite.CSV_STATUS, \
-    graphite.CSV_INTERNAL_ID, \
-    graphite.CSV_COLOR, \
-    graphite.CSV_MAIN_TYPE, \
-    graphite.CSV_ONCOTREE_CODE, \
+REQUIRED_FIELDS = [graphite.CSV_LABEL,
+    graphite.CSV_SCHEME_URI,
+    graphite.CSV_STATUS,
+    graphite.CSV_INTERNAL_ID,
+    graphite.CSV_COLOR,
+    graphite.CSV_MAIN_TYPE,
+    graphite.CSV_ONCOTREE_CODE,
     graphite.CSV_PREFERRED_LABEL]
-TISSUE_NODE_REQUIRED_FIELDS = [graphite.CSV_RESOURCE_URI, \
-    graphite.CSV_LABEL, \
-    graphite.CSV_SCHEME_URI, \
-    graphite.CSV_STATUS, \
-    graphite.CSV_INTERNAL_ID, \
-    graphite.CSV_ONCOTREE_CODE, \
+REQUIRED_FIELDS_ORIGINAL_FILE = REQUIRED_FIELDS + [graphite.CSV_RESOURCE_URI,
+    graphite.CSV_PARENT_RESOURCE_URI,                                          
+    graphite.CSV_PARENT_LABEL]
+TISSUE_NODE_REQUIRED_FIELDS = [graphite.CSV_RESOURCE_URI,
+    graphite.CSV_LABEL,
+    graphite.CSV_SCHEME_URI,
+    graphite.CSV_STATUS,
+    graphite.CSV_INTERNAL_ID,
+    graphite.CSV_ONCOTREE_CODE,
     graphite.CSV_PREFERRED_LABEL]
 
 def confirm_change(message):
     print(f"\n{message}")
     answer = input("Enter [y]es if the changes were intentional, [n]o if not: ")
     if answer.lower() in ["y","yes"]:
-        return True 
+        return True
     return False
 
 def construct_pretty_label_for_row(internal_id, code, label):
@@ -86,17 +89,17 @@ def get_parent_internal_id(child_internal_id, parent_resource_uri, parent_oncotr
     to look up the parent's internal id.  If the parent cannot be found this will throw an error."""
     # TODO have we validated these already? If so, skip the error checks?
     if parent_oncotree_code:
-        if parent_oncotree_code in oncotree_codes_to_internal_ids:    
+        if parent_oncotree_code in oncotree_codes_to_internal_ids:
             return oncotree_codes_to_internal_ids[parent_oncotree_code]
         else:
             print(f"Error: '{graphite.CSV_PARENT_ONCOTREE_CODE}' '{parent_oncotree_code}' not found in modified file", file=sys.stderr)
             sys.exit(1)
     if not parent_resource_uri:
-        print(f"Error: either '{graphite.CSV_PARENT_ONCOTREE_CODE}' or '{graphite.CSV_PARENT_RESOURCE_URI}' are required in the modified file, missing for '{child_internal_id}'", file=sys.stderr) 
+        print(f"Error: either '{graphite.CSV_PARENT_ONCOTREE_CODE}' or '{graphite.CSV_PARENT_RESOURCE_URI}' are required in the modified file, missing for '{child_internal_id}'", file=sys.stderr)
         sys.exit(1)
     # we must have the parent_resource_uri instead
     return resource_uri_to_internal_ids[parent_resource_uri]
-        
+
 def get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, internal_id):
     for code in oncotree_codes_to_internal_ids:
         if oncotree_codes_to_internal_ids[code] == internal_id:
@@ -104,93 +107,111 @@ def get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, internal_
     print(f"Error: could not find an oncotree code for internal id {internal_id}", file=sys.stderr)
     sys.exit(1)
 
-def confirm_changes(original_oncotree,
-                    modified_oncotree,
-                    precursor_id_to_internal_ids,
-                    revocation_id_to_internal_ids,
-                    original_resource_uri_to_internal_ids,
-                    modified_resource_uri_to_internal_ids,
-                    internal_id_to_oncocodes,
-                    oncotree_codes_to_internal_ids):
-    original_internal_id_set = set(original_oncotree.keys())
-    modified_internal_id_set = set(modified_oncotree.keys())
-
-    # get three sets of INTERNAL_IDs:
-    # 1) ones that have been removed
-    # 2) ones that are new
-    # 3) ones that are still there
-    # then handle each of the three sets
-    removed_internal_ids = original_internal_id_set - modified_internal_id_set
-    new_internal_ids = modified_internal_id_set - original_internal_id_set
-    in_both_internal_ids = original_internal_id_set & modified_internal_id_set
-
+def display_removed_internal_ids(removed_internal_ids, original_oncotree):
     print("\nRemoved internal ids:")
     if removed_internal_ids:
         for internal_id in sorted(removed_internal_ids):
             data = original_oncotree[internal_id]
-            pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
+            pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID],
+                                                          data[graphite.CSV_ONCOTREE_CODE],
+                                                          data[graphite.CSV_LABEL])
             print(f"\t{pretty_label}")
         print(f"\n****** All removed Oncotree nodes must be manually deleted from Graphite")
     else:
         print("\tNone")
 
+def validate_and_display_new_internal_ids(new_internal_ids,
+                             modified_oncotree,
+                             oncotree_codes_to_internal_ids,
+                             modified_resource_uri_to_internal_ids):
+    """Displays new internal ids and also throws an error if we have a new id
+       with a resource uri defined"""
     print("\nNew internal ids:")
     if new_internal_ids:
         for internal_id in sorted(new_internal_ids):
             data = modified_oncotree[internal_id]
-            pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
+            pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID],
+                                                          data[graphite.CSV_ONCOTREE_CODE],
+                                                          data[graphite.CSV_LABEL])
             if data[graphite.CSV_RESOURCE_URI]:
                 # we could allow this but we would have to make sure the resource uri is new and is valid - so let's not
-                print(f"Error: you cannot have a '{graphite.CSV_RESOURCE_URI}' for a new oncotree node '{pretty_label}'", file=sys.stderr) 
+                print(f"Error: you cannot have a '{graphite.CSV_RESOURCE_URI}' for a new oncotree node '{pretty_label}'", file=sys.stderr)
                 sys.exit(1)
             # show parent in "new" nodes
-            parent_internal_id = get_parent_internal_id(internal_id, data[graphite.CSV_PARENT_RESOURCE_URI], data[graphite.CSV_PARENT_ONCOTREE_CODE], oncotree_codes_to_internal_ids, modified_resource_uri_to_internal_ids)
+            parent_internal_id = get_parent_internal_id(internal_id,
+                                                        data[graphite.CSV_PARENT_RESOURCE_URI],
+                                                        data[graphite.CSV_PARENT_ONCOTREE_CODE],
+                                                        oncotree_codes_to_internal_ids,
+                                                        modified_resource_uri_to_internal_ids)
             parent_data = modified_oncotree[parent_internal_id]
-            parent_pretty_label = construct_pretty_label_for_row(parent_internal_id, parent_data[graphite.CSV_ONCOTREE_CODE], parent_data[graphite.CSV_LABEL])
+            parent_pretty_label = construct_pretty_label_for_row(parent_internal_id,
+                                                                 parent_data[graphite.CSV_ONCOTREE_CODE],
+                                                                 parent_data[graphite.CSV_LABEL])
             print(f"\t{pretty_label} has parent {parent_pretty_label}")
     else:
         print("\tNone")
 
+def validate_and_display_modified_precursors(modified_precursor_id_to_internal_ids,
+                                internal_ids_to_oncotree_codes,
+                                modified_internal_id_set,
+                                modified_oncotree):
+    """Displays precursors in the modified csv file.  Throws an error if the
+       precursor is also defined in the current file."""
     print("\nPrecurors:")
-    if precursor_id_to_internal_ids:
-        for precursor_id in sorted(precursor_id_to_internal_ids.keys()):
-            precursor_code = internal_id_to_oncocodes[precursor_id] if precursor_id in internal_id_to_oncocodes else "unknown"
+    if modified_precursor_id_to_internal_ids:
+        for precursor_id in sorted(modified_precursor_id_to_internal_ids.keys()):
+            precursor_code = internal_ids_to_oncotree_codes[precursor_id] if precursor_id in internal_ids_to_oncotree_codes else "unknown"
             # are any current concepts precursors? they shouldn't be
             if precursor_id in modified_internal_id_set:
-                print(f"Error: '{precursor_id}' ('{precursor_code}') is a precuror to '{','.join(precursor_id_to_internal_ids[precursor_id])}' but '{precursor_id}' is still in this file as a current record", file=sys.stderr)
+                print(f"Error: '{precursor_id}' ('{precursor_code}') is a precuror to '{','.join(modified_precursor_id_to_internal_ids[precursor_id])}' but '{precursor_id}' is still in this file as a current record", file=sys.stderr)
                 sys.exit(1)
-            precursor_of_set = precursor_id_to_internal_ids[precursor_id]
+            precursor_of_set = modified_precursor_id_to_internal_ids[precursor_id]
             for internal_id in precursor_of_set:
                 data = modified_oncotree[internal_id]
-                pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
+                pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID],
+                                                              data[graphite.CSV_ONCOTREE_CODE],
+                                                              data[graphite.CSV_LABEL])
                 print(f"\t'{precursor_id}' ('{precursor_code}') -> '{pretty_label}'")
     else:
         print("\tNone")
 
+def validate_and_display_modified_revocations(modified_revocation_id_to_internal_ids,
+                                 internal_ids_to_oncotree_codes,
+                                 modified_oncotree,
+                                 modified_internal_id_set,
+                                 modified_precursor_id_to_internal_ids,
+                                 new_internal_ids):
     print("\nRevocations:")
-    if revocation_id_to_internal_ids: 
-        for revocation_id in sorted(revocation_id_to_internal_ids.keys()):
-            revocation_code = internal_id_to_oncocodes[revocation_id] if revocation_id in internal_id_to_oncocodes else "unknown"
+    if modified_revocation_id_to_internal_ids:
+        for revocation_id in sorted(modified_revocation_id_to_internal_ids.keys()):
+            revocation_code = internal_ids_to_oncotree_codes[revocation_id] if revocation_id in internal_ids_to_oncotree_codes else "unknown"
             if revocation_id in modified_internal_id_set:
-                print(f"Error: '{revocation_id}' ('{revocation_code}') has been revoked by '{','.join(revocation_id_to_internal_ids[revocation_id])}' but '{revocation_id}' is still in this file as a current record", file=sys.stderr)
+                print(f"Error: '{revocation_id}' ('{revocation_code}') has been revoked by '{','.join(modified_revocation_id_to_internal_ids[revocation_id])}' but '{revocation_id}' is still in this file as a current record", file=sys.stderr)
                 sys.exit(1)
-            if revocation_id in precursor_id_to_internal_ids:
+            if revocation_id in modified_precursor_id_to_internal_ids:
                 print(f"Error: Revocation '{revocation_id}' ('{revocation_code}') cannot also be a precursor", file=sys.stderr)
                 sys.exit(1)
-            revocation_of_set = revocation_id_to_internal_ids[revocation_id]
-            for internal_id in revocation_of_set: 
+            revocation_of_set = modified_revocation_id_to_internal_ids[revocation_id]
+            for internal_id in revocation_of_set:
                 if internal_id in new_internal_ids:
                     print(f"Error: '{revocation_id}' ('{revocation_code}') revokes '{internal_id}' but '{internal_id}' is a new concept. Only a pre-existing concept can revoke something", file=sys.stderr)
                     sys.exit(1)
                 data = modified_oncotree[internal_id]
-                pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
+                pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID],
+                                                              data[graphite.CSV_ONCOTREE_CODE],
+                                                              data[graphite.CSV_LABEL])
                 print(f"\t'{revocation_id}' ('{revocation_code}') -> '{pretty_label}'")
     else:
         print("\tNone")
 
+def display_possible_id_changes(removed_internal_ids,
+                                new_internal_ids,
+                                original_oncotree,
+                                modified_oncotree):
+    """Displays cases where the internal id changed but no data changed.
+       In this case the internal id should not have been changed."""
     # compare all deleted and new internal ids to see if any are really the same - TODO what counts as "the same"?
-    print("\nInternal ids that changed when no other data has changed ... are these really new concepts that cover different sets of cancer cases?")
-    found_id_change_with_no_data_change = False
+    changed_ids = set()
     # compare all removed ids to new ids to see if any have the same data
     for pair in {(x, y) for x in removed_internal_ids for y in new_internal_ids}:
         original_data = original_oncotree[pair[0]]
@@ -198,15 +219,61 @@ def confirm_changes(original_oncotree,
         diff = DeepDiff(original_data, modified_data, ignore_order=True)
         # remove the change we know about (the internal id)
         diff['values_changed'] = {x : diff['values_changed'][x] for x in diff['values_changed'].keys() if x != f"root['{graphite.CSV_INTERNAL_ID}']"}
- 
+
         if not diff['values_changed']: # TODO do we care about anything besides values_changed?
             found_id_change_with_no_data_change = True
             original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID], original_data[graphite.CSV_ONCOTREE_CODE], original_data[graphite.CSV_LABEL])
             modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID], modified_data[graphite.CSV_ONCOTREE_CODE], modified_data[graphite.CSV_LABEL])
             # TODO what changes really are important?  probably not color for example
-            print(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
-    if not found_id_change_with_no_data_change:
-        print("\tNone")
+            changed_ids.add(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
+    if changed_ids:
+        print("\nInternal ids that changed when no other data has changed ... are these really new concepts that cover different sets of cancer cases?")
+        for changed_id in changed_ids:
+            print(changed_id)
+
+def validate_and_confirm_changes(original_oncotree,
+                    modified_oncotree,
+                    modified_precursor_id_to_internal_ids,
+                    modified_revocation_id_to_internal_ids,
+                    original_resource_uri_to_internal_ids,
+                    modified_resource_uri_to_internal_ids,
+                    internal_ids_to_oncotree_codes,
+                    oncotree_codes_to_internal_ids,
+                    modified_resource_uri_to_labels):
+    original_internal_id_set = set(original_oncotree.keys())
+    modified_internal_id_set = set(modified_oncotree.keys())
+
+    # get three sets of INTERNAL_IDs:
+    # 1) ones that have been removed
+    # 2) ones that are new
+    # 3) ones that are still there
+    # then validate and display information about each of the three sets
+    removed_internal_ids = original_internal_id_set - modified_internal_id_set
+    new_internal_ids = modified_internal_id_set - original_internal_id_set
+    in_both_internal_ids = original_internal_id_set & modified_internal_id_set
+
+    # the following display information about changes
+    # they also do throw errors if problems are found
+    # TODO pass params in same order
+    display_removed_internal_ids(removed_internal_ids, original_oncotree)
+    validate_and_display_new_internal_ids(new_internal_ids,
+                             modified_oncotree,
+                             oncotree_codes_to_internal_ids,
+                             modified_resource_uri_to_internal_ids)
+    validate_and_display_modified_precursors(modified_precursor_id_to_internal_ids,
+                                internal_ids_to_oncotree_codes,
+                                modified_internal_id_set,
+                                modified_oncotree)
+    validate_and_display_modified_revocations(modified_revocation_id_to_internal_ids,
+                                 internal_ids_to_oncotree_codes,
+                                 modified_oncotree,
+                                 modified_internal_id_set,
+                                 modified_precursor_id_to_internal_ids,
+                                 new_internal_ids)
+    display_possible_id_changes(removed_internal_ids,
+                                new_internal_ids,
+                                original_oncotree,
+                                modified_oncotree)
 
     # now we look at all interal ids that are in both files, what has changed about the data?
     code_change_messages = []
@@ -214,17 +281,21 @@ def confirm_changes(original_oncotree,
     for internal_id in in_both_internal_ids:
         original_data = original_oncotree[internal_id]
         modified_data = modified_oncotree[internal_id]
-        original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID], original_data[graphite.CSV_ONCOTREE_CODE], original_data[graphite.CSV_LABEL])
-        modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID], modified_data[graphite.CSV_ONCOTREE_CODE], modified_data[graphite.CSV_LABEL])
+        original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID],
+                                                               original_data[graphite.CSV_ONCOTREE_CODE],
+                                                               original_data[graphite.CSV_LABEL])
+        modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID],
+                                                               modified_data[graphite.CSV_ONCOTREE_CODE],
+                                                               modified_data[graphite.CSV_LABEL])
 
         # confirm we have resource uri in original file, we don't have to check modified file because we check if it has changed
         if original_data[graphite.CSV_RESOURCE_URI].strip() == "":
             print(f"ERROR: Resource URI is required for all records in the original file but is missing for '{original_pretty_label}'", file=sys.stderr)
-            sys.exit(1) 
+            sys.exit(1)
 
         if original_data[graphite.CSV_RESOURCE_URI] != modified_data[graphite.CSV_RESOURCE_URI]:
             print(f"ERROR: Resource URI has changed for '{modified_pretty_label}', this is not allowed", file=sys.stderr)
-            sys.exit(1) 
+            sys.exit(1)
 
         if original_data[graphite.CSV_ONCOTREE_CODE] != modified_data[graphite.CSV_ONCOTREE_CODE]:
             code_change_messages.append(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
@@ -233,15 +304,16 @@ def confirm_changes(original_oncotree,
             # check if parent has changed
             # use oncotree codes (we will get either have the oncotree code, or will get it using the resource uri)
             modified_parent_oncotree_code = modified_data[graphite.CSV_PARENT_ONCOTREE_CODE]
-            if not modified_parent_oncotree_code: 
+            if not modified_parent_oncotree_code:
                 # then get the oncotree code using resource uri -> internal id -> oncotree code
                 modified_parent_internal_id = get_parent_internal_id(internal_id,
                                                                      modified_data[graphite.CSV_PARENT_RESOURCE_URI],
                                                                      modified_data[graphite.CSV_PARENT_ONCOTREE_CODE],
                                                                      oncotree_codes_to_internal_ids,
                                                                      modified_resource_uri_to_internal_ids)
-                modified_parent_oncotree_code = get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, modified_parent_internal_id)
-    
+                modified_parent_oncotree_code = get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids,
+                                                                                   modified_parent_internal_id)
+
             # get the original parent oncotree code
             # in the original file we will have to look up the oncotree code using resource uri -> internal id -> oncotree code
             original_parent_internal_id = get_parent_internal_id(internal_id,
@@ -252,9 +324,9 @@ def confirm_changes(original_oncotree,
             original_parent_oncotree_code = get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, original_parent_internal_id)
             if original_parent_oncotree_code != modified_parent_oncotree_code:
                 parent_change_messages.append(f"\tchild: '{original_pretty_label}' parent: '{original_parent_oncotree_code}' -> child: '{modified_pretty_label}' parent: '{modified_parent_oncotree_code}'")
-        
 
-    print("\nOncotree code/label changes with no internal id change.  This is allowed as long as the new code/label covers the exact same set of cancer cases") 
+
+    print("\nOncotree code/label changes with no internal id change.  This is allowed as long as the new code/label covers the exact same set of cancer cases")
     if code_change_messages:
         for message in code_change_messages:
             print(message)
@@ -281,14 +353,14 @@ def get_oncotree_data_from_csv_file(csv_file):
         resource_uri_to_internal_ids,
         precursor_id_to_internal_ids,
         revocation_id_to_internal_ids,
-        oncotree_codes_to_internal_ids"""
+        resource_uri_to_labels"""
     with open(csv_file, 'r', encoding='utf-8-sig') as file:
         reader = csv.DictReader(file)
-        internal_id_to_data = {} 
+        internal_id_to_data = {}
         resource_uri_to_internal_ids = {}
         precursor_id_to_internal_ids = defaultdict(set)
         revocation_id_to_internal_ids = defaultdict(set)
-        oncotree_codes_to_internal_ids = {}
+        resource_uri_to_labels = {}
         for row in reader:
             internal_id = row[graphite.CSV_INTERNAL_ID]
             pretty_label = construct_pretty_label_for_row(internal_id, row[graphite.CSV_ONCOTREE_CODE], row[graphite.CSV_LABEL])
@@ -296,25 +368,24 @@ def get_oncotree_data_from_csv_file(csv_file):
                 print(f"WARNING: do not know what to do with node '{pretty_label}' which has a status of '{row[graphite.CSV_STATUS]}', excluding it from the output file")
             else:
                 internal_id_to_data[internal_id] = row
-                oncotree_codes_to_internal_ids[row[graphite.CSV_ONCOTREE_CODE]] = row[graphite.CSV_INTERNAL_ID]
                 if row[graphite.CSV_RESOURCE_URI]:
-                    print(f"row[graphite.CSV_RESOURCE_URI]={row[graphite.CSV_RESOURCE_URI]}")
                     resource_uri_to_internal_ids[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_INTERNAL_ID]
+                    resource_uri_to_labels[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_LABEL]
                 if row[graphite.CSV_PRECURSORS]:
                     for precursor_id in row[graphite.CSV_PRECURSORS].split(): # space separated
                         precursor_id_to_internal_ids[precursor_id].add(row[graphite.CSV_INTERNAL_ID])
                 if row[graphite.CSV_REVOCATIONS]:
                     for revocation_id in row[graphite.CSV_REVOCATIONS].split(): # space separated
                         revocation_id_to_internal_ids[revocation_id].add(row[graphite.CSV_INTERNAL_ID])
-        return internal_id_to_data, \
-            resource_uri_to_internal_ids, \
-            precursor_id_to_internal_ids, \
-            revocation_id_to_internal_ids, \
-            oncotree_codes_to_internal_ids
+        return (internal_id_to_data,
+            resource_uri_to_internal_ids,
+            precursor_id_to_internal_ids,
+            revocation_id_to_internal_ids,
+            resource_uri_to_labels)
 
 def field_is_required(field, field_name, internal_id, csv_file):
     if not field:
-        print(f"{field_name} is a required field, it is empty for the '{internal_id}' record in '{csv_file}'", file=sys.stderr)
+        print(f"'{field_name}' is a required field in '{csv_file}'. It is empty for '{internal_id}'", file=sys.stderr)
         sys.exit(1)
 
 def field_is_unique(field, field_name, column_set, internal_id, csv_file):
@@ -323,28 +394,28 @@ def field_is_unique(field, field_name, column_set, internal_id, csv_file):
         print(f"{field_name} must be unique.  There is more than one record with '{field}' in '{csv_file}'", file=sys.stderr)
         sys.exit(1)
 
-def parent_oncotree_code_is_valid(row, 
+def parent_oncotree_code_is_valid(row,
                                   oncotree_codes_to_internal_ids):
     return row[graphite.CSV_PARENT_ONCOTREE_CODE] in oncotree_codes_to_internal_ids
-   
+
 def parent_definition_in_conflict(row,
-                                  oncotree_codes_to_internal_ids,              
-                                  resource_uri_to_internal_ids): 
+                                  oncotree_codes_to_internal_ids,
+                                  resource_uri_to_internal_ids):
     """There is a conflict if we have both the parent oncotree code
        and the parent resource uri and they don't point to the same child"""
     return (row[graphite.CSV_PARENT_RESOURCE_URI] and
             row[graphite.CSV_PARENT_ONCOTREE_CODE] and
-            resource_uri_to_internal_ids[row[graphite.CSV_PARENT_RESOURCE_URI]] != \
+            resource_uri_to_internal_ids[row[graphite.CSV_PARENT_RESOURCE_URI]] !=
                 oncotree_codes_to_internal_ids[row[graphite.CSV_PARENT_ONCOTREE_CODE]])
 
 def parent_resource_uri_and_label_are_valid(row,
-                                            child_to_parent_resource_uris,
-                                            child_uri_to_child_label)
+                                            resource_uri_to_internal_ids,
+                                            resource_uri_to_labels):
     """Both the parent label and URI must be defined in this file
         and the parent URI must point to a child with the label we
         have defined for the parent."""
-    return (row[graphite.CSV_PARENT_RESOURCE_URI] in child_to_parent_resource_uris and
-            row[graphite.CSV_PARENT_LABEL] == child_uri_to_child_label[row[graphite.CSV_PARENT_RESOURCE_URI]])
+    return (row[graphite.CSV_PARENT_RESOURCE_URI] in resource_uri_to_internal_ids and
+            row[graphite.CSV_PARENT_LABEL] == resource_uri_to_labels[row[graphite.CSV_PARENT_RESOURCE_URI]])
 
 def parent_is_defined(oncotree_code,
                       parent_resource_uri,
@@ -360,91 +431,86 @@ def using_oncotree_code_to_define_parent(row):
 def is_tissue_node(row):
     return row[graphite.CSV_ONCOTREE_CODE] == "TISSUE"
 
+def required_fields_defined(row, required_fields):
+    row_required_fields = TISSUE_NODE_REQUIRED_FIELDS if is_tissue_node(row) else required_fields
+    for field in row_required_fields:
+        field_is_required(row[field], field, row[graphite.CSV_INTERNAL_ID], csv_file)
+
+def parent_is_defined_if_not_tissue(row):
+    if not is_tissue_node(row):
+        parent_oncotree_code = "" if graphite.CSV_PARENT_ONCOTREE_CODE not in row else row[graphite.CSV_PARENT_ONCOTREE_CODE]
+        parent_is_defined(row[graphite.CSV_ONCOTREE_CODE], row[graphite.CSV_PARENT_RESOURCE_URI], row[graphite.CSV_PARENT_LABEL], parent_oncotree_code)
+
+def has_no_parents(row):
+    # the TISSUE node cannot have any parents set
+    if (row[graphite.CSV_PARENT_RESOURCE_URI] or
+        row[graphite.CSV_PARENT_LABEL] or
+        using_oncotree_code_to_define_parent(row)):
+        print(f"The '{graphite.CSV_LABEL}' node must not have any of these fields set: '{graphite.CSV_PARENT_RESOURCE_URI}', '{graphite.CSV_PARENT_LABEL}', '{graphite.CSV_PARENT_LABEL}' but at least one is in '{csv_file}'", file=sys.stderr)
+        sys.exit(1)
+
 def validate_csv_file(csv_file,
                       expected_header,
+                      required_fields,
                       resource_uri_to_internal_ids,
-                      oncotree_codes_to_internal_ids):
-    # read the file once to do some checks and also to collect data
-    # so we can do more checks in a second pass at reading the file
-    # load all child->parent relationships
-    # TODO get this from earlier too
-    child_uri_to_child_label = {} # make sure the parent uri + label match the child uri + label pair
-
+                      oncotree_codes_to_internal_ids,
+                      resource_uri_to_labels):
     # these fields are required and must be unique
-    # TODO get these from somewhere else
     resource_uri_set = set([])
     internal_id_set = set([])
     oncotree_code_set = set([])
+
     with open(csv_file, 'r', encoding='utf-8-sig') as file:
         reader = csv.DictReader(file)
+        # validate header
         actual_header = reader.fieldnames
         missing_fields = set(expected_header) - set(actual_header)
         if missing_fields:
-            print(f"ERROR: missing the following expected fields from input file '{csv_file}': {missing_fields}", file=sys.stderr)
+            print(f"ERROR: missing the following expected fields from input file '{csv_file}': {', '.join(missing_fields)}", file=sys.stderr)
             sys.exit(1)
 
+        label_mismatch_errors = []
+        parent_invalid_errors = []
         for row in reader:
-            # save child->parent relationships
-            child_uri_to_child_label[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_LABEL]
-            child_to_parent_labels[row[graphite.CSV_LABEL]] = row[graphite.CSV_PARENT_LABEL] 
-            oncotree_codes_to_internal_ids[row[graphite.CSV_ONCOTREE_CODE]] = row[graphite.CSV_INTERNAL_ID]
-
-            # check all colunns are not empty
-            required_fields = TISSUE_NODE_REQUIRED_FIELDS if is_tissue_node(row) else REQUIRED_FIELDS
-            for field in required_fields:
-                field_is_required(row[field], field, row[graphite.CSV_INTERNAL_ID], csv_file)  
-           
-            if not is_tissue_node(row):
-                parent_oncotree_code = "" if graphite.CSV_PARENT_ONCOTREE_CODE not in row else row[graphite.CSV_PARENT_ONCOTREE_CODE] 
-                parent_is_defined(row[graphite.CSV_ONCOTREE_CODE], row[graphite.CSV_PARENT_RESOURCE_URI], row[graphite.CSV_PARENT_LABEL], parent_oncotree_code)
+            required_fields_defined(row, required_fields)
+            parent_is_defined_if_not_tissue(row) 
 
             # check these columns are unique
             field_is_unique(row[graphite.CSV_RESOURCE_URI], graphite.CSV_RESOURCE_URI, resource_uri_set, row[graphite.CSV_INTERNAL_ID], csv_file)
             field_is_unique(row[graphite.CSV_INTERNAL_ID], graphite.CSV_INTERNAL_ID, internal_id_set, row[graphite.CSV_ONCOTREE_CODE], csv_file)
             field_is_unique(row[graphite.CSV_ONCOTREE_CODE], graphite.CSV_ONCOTREE_CODE, oncotree_code_set, row[graphite.CSV_INTERNAL_ID], csv_file)
-
             resource_uri_set.add(row[graphite.CSV_RESOURCE_URI])
             internal_id_set.add(row[graphite.CSV_INTERNAL_ID])
             oncotree_code_set.add(row[graphite.CSV_ONCOTREE_CODE])
 
-    # now read again once we have collected all ids etc. so we can look things up and make sure references are correct
-    with open(csv_file, 'r', encoding='utf-8-sig') as file:
-        reader = csv.DictReader(file)
-        label_mismatch_errors = []
-        parent_invalid_errors = []
-        for row in reader:
+            # check 2 label fields are the same
             if row[graphite.CSV_LABEL] != row[graphite.CSV_PREFERRED_LABEL]:
                 label_mismatch_errors.append(f"{row[graphite.CSV_INTERNAL_ID]}: '{row[graphite.CSV_LABEL]}' != '{row[graphite.CSV_PREFERRED_LABEL]}'")
+
             if is_tissue_node(row):
-                # the TISSUE node cannot have any parents set
-                if (row[graphite.CSV_PARENT_RESOURCE_URI] or
-                    row[graphite.CSV_PARENT_LABEL] or
-                    using_oncotree_code_to_define_parent(row)):
-                    print(f"The 'TISSUE' node must not have any of these fields set: '{graphite.CSV_PARENT_RESOURCE_URI}', '{graphite.CSV_PARENT_LABEL}', '{graphite.CSV_PARENT_LABEL}' but at least one is in '{csv_file}'", file=sys.stderr)
-                    sys.exit(1)
-            # this isn't the TISSUE node
-            # we are defining the parent using the oncotree code, so check that is valid
-            elif using_oncotree_code_to_define_parent(row):
-                if not parent_oncotree_code_is_valid(row, oncotree_codes_to_internal_ids): 
+                has_no_parents(row)
+            elif using_oncotree_code_to_define_parent(row): # this isn't the TISSUE node 
+                # we are defining the parent using the oncotree code, so check that is valid
+                if not parent_oncotree_code_is_valid(row, oncotree_codes_to_internal_ids):
                     parent_invalid_errors.append(f"Child '{row[graphite.CSV_ONCOTREE_CODE]}' has parent oncotree code '{row[graphite.CSV_PARENT_ONCOTREE_CODE]}' which doesn't map to anything in file '{csv_file}'")
                 elif parent_definition_in_conflict(row,
                                                    oncotree_codes_to_internal_ids,
                                                    resource_uri_to_internal_ids):
                     parent_invalid_errors.append(f"Error: Child '{row[graphite.CSV_ONCOTREE_CODE]}' has parent oncotree code '{row[graphite.CSV_PARENT_ONCOTREE_CODE]}' which maps to internal id '{oncotree_codes_to_internal_ids[row[graphite.CSV_PARENT_ONCOTREE_CODE]]}' this is in conflict with the resource uri defined for the parent '{row[graphite.CSV_PARENT_RESOURCE_URI]}' which maps to internal id '{resource_uri_to_internal_ids[row[graphite.CSV_PARENT_RESOURCE_URI]]}'.  Which one is the parent?")
-            # we are defining the parent with the resource uri + label
-            # we need to make sure the parent resource uri/label pair
-            # matches what exists in the file
-            elif not parent_resource_uri_and_label_are_valid(row,
-                   child_to_parent_resource_uris,
-                   child_uri_to_child_label,
-                   child_to_parent_labels):
+    
+            elif not parent_resource_uri_and_label_are_valid(row, # this isn't the TISSUE node 
+                   resource_uri_to_internal_ids,
+                   resource_uri_to_labels):
+                # we are defining the parent with the resource uri + label
+                # we need to make sure the parent resource uri/label pair
+                # matches what exists in the file
                 parent_invalid_errors.append(f"{row[graphite.CSV_INTERNAL_ID]}: URI '{row[graphite.CSV_PARENT_RESOURCE_URI]}' and label '{row[graphite.CSV_PARENT_LABEL]}'")
 
     if label_mismatch_errors:
         print(f"ERROR: '{graphite.CSV_LABEL}' and '{graphite.CSV_PREFERRED_LABEL}' columns must be identical.  Mis-matched fields in '{csv_file}':")
         for message in label_mismatch_errors:
             print(f"\t{message}")
-    
+
     if parent_invalid_errors:
         print(f"ERROR: Invalid parents found in '{csv_file}'.  Check that the oncotree code is valid if it was entered, or if you are using the resource uri/label pair, that they are defined in '{csv_file}'")
         for message in parent_invalid_errors:
@@ -453,18 +519,20 @@ def validate_csv_file(csv_file,
     if label_mismatch_errors or parent_invalid_errors:
         sys.exit(1)
 
-def get_internal_id_to_oncocodes():
-    response = requests.get(GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL) 
+def get_internal_ids_to_oncotree_codes():
+    response = requests.get(GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL)
     if response.status_code != 200:
         print(f"Error: Failed to download GitHub raw resource uri to oncoode file. Status code was '{response.status_code}'.  Please confirm this is the correct url: '{GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL}'", file=sys.stderr)
         sys.exit(1)
-    internal_id_to_oncocodes = {}
+    internal_ids_to_oncotree_codes = {}
+    oncotree_codes_to_internal_ids = {}
     for row in response.text.splitlines():
         fields = row.split()
         if fields[1] == "hasCode":
-            internal_id_to_oncocodes[fields[0]] = fields[2]    
-    return internal_id_to_oncocodes
- 
+            internal_ids_to_oncotree_codes[fields[0]] = fields[2]
+            oncotree_codes_to_internal_ids[fields[2]] = fields[0]
+    return internal_ids_to_oncotree_codes, oncotree_codes_to_internal_ids
+
 def usage(parser, message):
     if message:
         print(message, file=sys.stderr)
@@ -492,7 +560,7 @@ def get_args():
     modified_file = args.modified_file
     output_file = args.output_file
 
-    if not original_file or not modified_file: 
+    if not original_file or not modified_file:
         usage(parser, f"ERROR: missing file arguments, given original file '{original_file}' and modified file '{modified_file}'")
 
     if not os.path.isfile(original_file):
@@ -506,7 +574,7 @@ def get_args():
     if not os.path.isfile(modified_file):
         usage(parser, f"ERROR: cannot access modified file {modified_file}")
         sys.exit(1)
-    
+
     return original_file, modified_file, output_file
 
 def main():
@@ -514,39 +582,44 @@ def main():
     original_file, modified_file, output_file = get_args()
 
     # 1. query Github for the offical internal id to oncotree code mapping
-    internal_id_to_oncocodes = get_internal_id_to_oncocodes()
+    internal_ids_to_oncotree_codes, oncotree_codes_to_internal_ids = get_internal_ids_to_oncotree_codes()
 
     # 2. read the csv data and put into various data structures to look things up later
     original_oncotree, \
         original_resource_uri_to_internal_ids, \
         _, \
         _, \
-        original_oncotree_codes_to_internal_ids = get_oncotree_data_from_csv_file(original_file)
+        original_resource_uri_to_labels = get_oncotree_data_from_csv_file(original_file)
     modified_oncotree, \
         modified_resource_uri_to_internal_ids, \
-        precursor_id_to_internal_ids, \
-        revocation_id_to_internal_ids, \
-        modified_oncotree_codes_to_internal_ids = get_oncotree_data_from_csv_file(modified_file)
+        modified_precursor_id_to_internal_ids, \
+        modified_revocation_id_to_internal_ids, \
+        modified_resource_uri_to_labels = get_oncotree_data_from_csv_file(modified_file)
 
     # 3. validate
-    validate_csv_file(original_file, \ 
-                      EXPECTED_HEADER, \ 
-                      original_resource_uri_to_internal_ids, \ 
-                      original_oncotree_codes_to_internal_ids)
-    validate_csv_file(modified_file, \ 
-                      EXPECTED_HEADER_MODIFIED_FILE, \ 
-                      modified_resource_uri_to_internal_ids, \ 
-                      modified_oncotree_codes_to_internal_ids)
+    validate_csv_file(original_file,
+                      EXPECTED_HEADER,
+                      REQUIRED_FIELDS_ORIGINAL_FILE,
+                      original_resource_uri_to_internal_ids,
+                      oncotree_codes_to_internal_ids,
+                      original_resource_uri_to_labels)
+    validate_csv_file(modified_file,
+                      EXPECTED_HEADER_MODIFIED_FILE,
+                      REQUIRED_FIELDS,
+                      modified_resource_uri_to_internal_ids,
+                      oncotree_codes_to_internal_ids,
+                      modified_resource_uri_to_labels)
 
     # 4. say what has changed and confirm they are wanted
-    confirm_changes(original_oncotree,
+    validate_and_confirm_changes(original_oncotree,
                     modified_oncotree,
-                    precursor_id_to_internal_ids,
-                    revocation_id_to_internal_ids,
+                    modified_precursor_id_to_internal_ids,
+                    modified_revocation_id_to_internal_ids,
                     original_resource_uri_to_internal_ids,
                     modified_resource_uri_to_internal_ids,
-                    internal_id_to_oncocodes,
-                    oncotree_codes_to_internal_ids)
+                    internal_ids_to_oncotree_codes,
+                    oncotree_codes_to_internal_ids,
+                    modified_resource_uri_to_labels)
 
     # 5. generate rdf from the data
     output_rdf_file(modified_oncotree, output_file)

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -212,8 +212,12 @@ def display_possible_id_changes(removed_internal_ids,
 
         if not diff['values_changed']: # do we care about anything besides values_changed?
             found_id_change_with_no_data_change = True
-            original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID], original_data[graphite.CSV_ONCOTREE_CODE], original_data[graphite.CSV_LABEL])
-            modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID], modified_data[graphite.CSV_ONCOTREE_CODE], modified_data[graphite.CSV_LABEL])
+            original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID],
+                                                                   original_data[graphite.CSV_ONCOTREE_CODE],
+                                                                   original_data[graphite.CSV_LABEL])
+            modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID],
+                                                                   modified_data[graphite.CSV_ONCOTREE_CODE],
+                                                                   modified_data[graphite.CSV_LABEL])
             # what changes really are important?  probably not color for example
             changed_ids.add(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
     if changed_ids:

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -16,18 +16,20 @@
 # Memorial Sloan-Kettering Cancer Center
 # has been advised of the possibility of such damage.
 
-# TODO think about status - should we even be looking at it? why would the new data be 'Published'
+# TODO modified file will have extra column at end which will take onctoree codes as parent - require that 2 parent columns before it have been deleted, then I can generate UUID URIs and get the label
+# TODO maybe only show changes to precursors/revocations? instead of the whole history
+# TODO what to do about deletes? Maybe discuss with Rob? -- for now tell them to manually delete them
 
 import argparse
 from collections import defaultdict
 import csv
 from deepdiff import DeepDiff
-#from deepdiff import DeepSearch
-#from deepdiff import grep
 import os
-#from pprint import pprint # TODO delete?
+import requests
 import sys
 
+GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL = "https://raw.githubusercontent.com/cBioPortal/oncotree/refs/heads/master/resources/resource_uri_to_oncocode_mapping.txt"
+HELP_FOR_FILE_FORMAT = "In the Graphite 'Concept Manager' left sidebar 'Hierarchy' tab, select your oncotree version, then click on the 'Export' tab in the main panel.  For 'File Format' select 'CSV (Dynamic Property Columns)'. In the 'Include' section uncheck everything except 'Non-primary concept URI' and 'Status'.  In the 'Select Properties to Export' all fields in both 'OncoTree Tumor Type' and 'SKOS' should be selected."
 LABEL = "Primary Concept"
 RESOURCE_URI = "Resource URI"
 ONCOTREE_CODE = "notation (SKOS)"
@@ -41,9 +43,10 @@ PREFERRED_LABEL = "preferred label (SKOS)"
 REVOCATIONS = "revocations (OncoTree Tumor Type)"
 PARENT_RESOURCE_URI = "has broader (SKOS) URI"
 PARENT_LABEL = "has broader (SKOS)"
-# TODO explain exactly how to generate this file in Graphite here and in usage
+PARENT_ONCOTREE_CODE = "parent oncotree code"
 EXPECTED_HEADER = [RESOURCE_URI, LABEL, SCHEME_URI, STATUS, INTERNAL_ID, COLOR, MAIN_TYPE, ONCOTREE_CODE, PRECURSORS, PREFERRED_LABEL, REVOCATIONS, PARENT_RESOURCE_URI, PARENT_LABEL]
-REQUIRED_FIELDS = [RESOURCE_URI, LABEL, SCHEME_URI, STATUS, INTERNAL_ID, COLOR, MAIN_TYPE, ONCOTREE_CODE, PREFERRED_LABEL, PARENT_RESOURCE_URI, PARENT_LABEL]
+EXPECTED_HEADER_MODIFIED_FILE = EXPECTED_HEADER + [PARENT_ONCOTREE_CODE]
+REQUIRED_FIELDS = [LABEL, SCHEME_URI, STATUS, INTERNAL_ID, COLOR, MAIN_TYPE, ONCOTREE_CODE, PREFERRED_LABEL, PARENT_RESOURCE_URI, PARENT_LABEL]
 TISSUE_NODE_REQUIRED_FIELDS = [RESOURCE_URI, LABEL, SCHEME_URI, STATUS, INTERNAL_ID, ONCOTREE_CODE, PREFERRED_LABEL]
 
 def confirm_change(message):
@@ -85,7 +88,51 @@ def get_all_revocations(csv_file):
                     revocation_id_to_internal_ids[revocation_id].add(row[INTERNAL_ID])
         return revocation_id_to_internal_ids   
 
-def confirm_changes(original_oncotree, modified_oncotree, precursor_id_to_internal_ids, revocation_id_to_internal_ids):
+def get_resource_uri_to_internal_ids(csv_file):
+    with open(csv_file, 'r', encoding='utf-8-sig') as file:
+        reader = csv.DictReader(file)
+        resource_uri_to_internal_ids = {}
+        for row in reader:
+            resource_uri_to_internal_ids[row[RESOURCE_URI]] = row[INTERNAL_ID]
+        return resource_uri_to_internal_ids
+
+def get_oncotree_codes_to_internal_ids(csv_file):
+    with open(csv_file, 'r', encoding='utf-8-sig') as file:
+        reader = csv.DictReader(file)
+        oncotree_codes_to_internal_ids = {}
+        for row in reader:
+            oncotree_codes_to_internal_ids[row[ONCOTREE_CODE]] = row[INTERNAL_ID]
+        return oncotree_codes_to_internal_ids
+
+def get_parent_internal_id(child_internal_id, parent_resource_uri, parent_oncotree_code, oncotree_codes_to_internal_ids, resource_uri_to_internal_ids):
+    if parent_oncotree_code:
+        # TODO validate parent_oncotree_codes in validate method?
+        if parent_oncotree_code in oncotree_codes_to_internal_ids:    
+            return oncotree_codes_to_internal_ids[parent_oncotree_code]
+        else:
+            print(f"Error: '{PARENT_ONCOTREE_CODE}' '{parent_oncotree_code}' not found in modified file", file=sys.stderr)
+            sys.exit(1)
+    if not parent_resource_uri:
+        print(f"Error: either '{PARENT_ONCOTREE_CODE}' or '{PARENT_RESOURCE_URI}' are required in the modified file, missing for '{child_internal_id}'", file=sys.stderr) 
+        sys.exit(1)
+    # we must have the parent_resource_uri instead
+    return resource_uri_to_internal_ids[parent_resource_uri]
+        
+def get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, internal_id):
+    for code in oncotree_codes_to_internal_ids:
+        if oncotree_codes_to_internal_ids[code] == internal_id:
+            return code
+    print(f"Error: could not find an oncotree code for internal id {internal_id}", file=sys.stderr)
+    sys.exit(1)
+
+def confirm_changes(original_oncotree,
+                    modified_oncotree,
+                    precursor_id_to_internal_ids,
+                    revocation_id_to_internal_ids,
+                    original_resource_uri_to_internal_ids,
+                    modified_resource_uri_to_internal_ids,
+                    internal_id_to_oncocodes,
+                    oncotree_codes_to_internal_ids):
     original_internal_id_set = set(original_oncotree.keys())
     modified_internal_id_set = set(modified_oncotree.keys())
 
@@ -110,6 +157,7 @@ def confirm_changes(original_oncotree, modified_oncotree, precursor_id_to_intern
             data = original_oncotree[internal_id]
             pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
             print(f"\t{pretty_label}")
+        print(f"\n****** All removed Oncotree nodes must be manually deleted from Graphite")
     else:
         print("\tNone")
 
@@ -118,58 +166,65 @@ def confirm_changes(original_oncotree, modified_oncotree, precursor_id_to_intern
         for internal_id in sorted(new_internal_ids):
             data = modified_oncotree[internal_id]
             pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
-            print(f"\t{pretty_label}")
+            if data[RESOURCE_URI]:
+                # we could allow this but we would have to make sure the resource uri is new and is valid - so let's not
+                print(f"Error: you cannot have a '{RESOURCE_URI}' for a new oncotree node '{pretty_label}'", file=sys.stderr) 
+                sys.exit(1)
+            # show parent in "new" nodes
+            parent_internal_id = get_parent_internal_id(internal_id, data[PARENT_RESOURCE_URI], data[PARENT_ONCOTREE_CODE], oncotree_codes_to_internal_ids, modified_resource_uri_to_internal_ids)
+            parent_data = modified_oncotree[parent_internal_id]
+            parent_pretty_label = construct_pretty_label_for_row(parent_internal_id, parent_data[ONCOTREE_CODE], parent_data[LABEL])
+            print(f"\t{pretty_label} has parent {parent_pretty_label}")
     else:
         print("\tNone")
 
     print("\nPrecurors:")
     if precursor_id_to_internal_ids:
         for precursor_id in sorted(precursor_id_to_internal_ids.keys()):
+            precursor_code = internal_id_to_oncocodes[precursor_id] if precursor_id in internal_id_to_oncocodes else "unknown"
             # are any current concepts precursors? they shouldn't be
             if precursor_id in modified_internal_id_set:
-                print(f"Error: '{precursor_id}' is a precuror to '{','.join(precursor_id_to_internal_ids[precursor_id])}' but '{precursor_id}' is still in this file as a current record", file=sys.stderr)
+                print(f"Error: '{precursor_id}' ('{precursor_code}') is a precuror to '{','.join(precursor_id_to_internal_ids[precursor_id])}' but '{precursor_id}' is still in this file as a current record", file=sys.stderr)
                 sys.exit(1)
             precursor_of_set = precursor_id_to_internal_ids[precursor_id]
             for internal_id in precursor_of_set:
                 data = modified_oncotree[internal_id]
                 pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
-                print(f"\t'{precursor_id}' -> '{pretty_label}'")
+                print(f"\t'{precursor_id}' ('{precursor_code}') -> '{pretty_label}'")
     else:
         print("\tNone")
 
     print("\nRevocations:")
     if revocation_id_to_internal_ids: 
         for revocation_id in sorted(revocation_id_to_internal_ids.keys()):
+            revocation_code = internal_id_to_oncocodes[revocation_id] if revocation_id in internal_id_to_oncocodes else "unknown"
             if revocation_id in modified_internal_id_set:
-                print(f"Error: '{revocation_id}' has been revoked by '{','.join(revocation_id_to_internal_ids[revocation_id])}' but '{revocation_id}' is still in this file as a current record", file=sys.stderr)
+                print(f"Error: '{revocation_id}' ('{revocation_code}') has been revoked by '{','.join(revocation_id_to_internal_ids[revocation_id])}' but '{revocation_id}' is still in this file as a current record", file=sys.stderr)
                 sys.exit(1)
             if revocation_id in precursor_id_to_internal_ids:
-                print(f"Error: Revocation '{revocation_id}' cannot also be a precursor", file=sys.stderr)
+                print(f"Error: Revocation '{revocation_id}' ('{revocation_code}') cannot also be a precursor", file=sys.stderr)
                 sys.exit(1)
             revocation_of_set = revocation_id_to_internal_ids[revocation_id]
             for internal_id in revocation_of_set: 
                 if internal_id in new_internal_ids:
-                    print(f"Error: '{revocation_id}' revokes '{internal_id}' but '{internal_id}' is a new concept. Only a pre-existing concept can revoke something", file=sys.stderr)
+                    print(f"Error: '{revocation_id}' ('{revocation_code}') revokes '{internal_id}' but '{internal_id}' is a new concept. Only a pre-existing concept can revoke something", file=sys.stderr)
                     sys.exit(1)
                 data = modified_oncotree[internal_id]
                 pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
-                print(f"\t'{revocation_id}' -> '{pretty_label}'")
+                print(f"\t'{revocation_id}' ('{revocation_code}') -> '{pretty_label}'")
     else:
         print("\tNone")
 
     # compare all deleted and new internal ids to see if any are really the same - TODO what counts as "the same"?
     print("\nInternal ids that changed when no other data has changed ... are these really new concepts that cover different sets of cancer cases?")
     found_id_change_with_no_data_change = False
+    # compare all removed ids to new ids to see if any have the same data
     for pair in {(x, y) for x in removed_internal_ids for y in new_internal_ids}:
-        #print(pair)
         original_data = original_oncotree[pair[0]]
         modified_data = modified_oncotree[pair[1]]
-        # TODO refactor and redo this section
         diff = DeepDiff(original_data, modified_data, ignore_order=True)
-        #print(diff)
-        # remove the change we know about
+        # remove the change we know about (the internal id)
         diff['values_changed'] = {x : diff['values_changed'][x] for x in diff['values_changed'].keys() if x != f"root['{INTERNAL_ID}']"}
-        #print(diff)
  
         if not diff['values_changed']: # TODO do we care about anything besides values_changed?
             found_id_change_with_no_data_change = True
@@ -189,19 +244,42 @@ def confirm_changes(original_oncotree, modified_oncotree, precursor_id_to_intern
         original_pretty_label = construct_pretty_label_for_row(original_data[INTERNAL_ID], original_data[ONCOTREE_CODE], original_data[LABEL])
         modified_pretty_label = construct_pretty_label_for_row(modified_data[INTERNAL_ID], modified_data[ONCOTREE_CODE], modified_data[LABEL])
 
-        # see what has changed 
-        diff = DeepDiff(original_data, modified_data, ignore_order=True)
-        if diff:
-            #print(diff)
-            if original_data[RESOURCE_URI] != modified_data[RESOURCE_URI]:
-                print(f"ERROR: Resource URI has changed for '{modified_pretty_label}', this is not allowed", file=sys.stderr)
-                sys.exit(1) 
+        # confirm we have resource uri in original file, we don't have to check modified file because we check if it has changed
+        if original_data[RESOURCE_URI].strip() == "":
+            print(f"ERROR: Resource URI is required for all records in the original file but is missing for '{original_pretty_label}'", file=sys.stderr)
+            sys.exit(1) 
 
-            if original_data[ONCOTREE_CODE] != modified_data[ONCOTREE_CODE]:
-                code_change_messages.append(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
+        if original_data[RESOURCE_URI] != modified_data[RESOURCE_URI]:
+            print(f"ERROR: Resource URI has changed for '{modified_pretty_label}', this is not allowed", file=sys.stderr)
+            sys.exit(1) 
 
-            if original_data[PARENT_LABEL] != modified_data[PARENT_LABEL]:
-                parent_change_messages.append(f"\tchild: '{original_pretty_label}' parent: '{original_data[PARENT_LABEL]}' -> child: '{modified_pretty_label}' parent: '{modified_data[PARENT_LABEL]}'")
+        if original_data[ONCOTREE_CODE] != modified_data[ONCOTREE_CODE]:
+            code_change_messages.append(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
+
+        if internal_id != "ONC000001": # tissue has no parents
+            # check if parent has changed
+            # use oncotree codes (we will get either have the oncotree code, or will get it using the resource uri)
+            modified_parent_oncotree_code = modified_data[PARENT_ONCOTREE_CODE]
+            if not modified_parent_oncotree_code: 
+                # then get the oncotree code using resource uri -> internal id -> oncotree code
+                modified_parent_internal_id = get_parent_internal_id(internal_id,
+                                                                     modified_data[PARENT_RESOURCE_URI],
+                                                                     modified_data[PARENT_ONCOTREE_CODE],
+                                                                     oncotree_codes_to_internal_ids,
+                                                                     modified_resource_uri_to_internal_ids)
+                modified_parent_oncotree_code = get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, modified_parent_internal_id)
+    
+            # get the original parent oncotree code
+            # in the original file we will have to look up the oncotree code using resource uri -> internal id -> oncotree code
+            original_parent_internal_id = get_parent_internal_id(internal_id,
+                                                                 original_data[PARENT_RESOURCE_URI],
+                                                                 None, # this file doesn't have a parent oncotree code column
+                                                                 oncotree_codes_to_internal_ids,
+                                                                 original_resource_uri_to_internal_ids)
+            original_parent_oncotree_code = get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, original_parent_internal_id)
+            if original_parent_oncotree_code != modified_parent_oncotree_code:
+                parent_change_messages.append(f"\tchild: '{original_pretty_label}' parent: '{original_parent_oncotree_code}' -> child: '{modified_pretty_label}' parent: '{modified_parent_oncotree_code}'")
+        
 
     print("\nOncotree code/label changes with no internal id change.  This is allowed as long as the new code/label covers the exact same set of cancer cases") 
     if code_change_messages:
@@ -243,11 +321,17 @@ def field_is_required(field, field_name, internal_id, csv_file):
         sys.exit(1)
 
 def field_is_unique(field, field_name, column_set, internal_id, csv_file):
-    if field in column_set:
+    # don't count "" duplicates -- these should be dealth with in required field check
+    if field != "" and field in column_set:
         print(f"{field_name} must be unique.  There is more than one record with '{field}' in '{csv_file}'", file=sys.stderr)
         sys.exit(1)
 
-def validate_csv_file(csv_file):
+def parent_resource_uri_and_label_are_valid(parent_resource_uri, parent_label, child_to_parent_resource_uris, child_uri_to_child_label, child_to_parent_labels):
+    return parent_label in child_to_parent_labels \
+                  and parent_label in child_to_parent_resource_uris \
+                  and (child_uri_to_child_label[parent_label] == parent_label)
+
+def validate_csv_file(csv_file, expected_header):
     # load all child->parent relationships
     # also check header and uniqueness and required values for some columns
     child_to_parent_resource_uris = {}
@@ -261,8 +345,9 @@ def validate_csv_file(csv_file):
     with open(csv_file, 'r', encoding='utf-8-sig') as file:
         reader = csv.DictReader(file)
         actual_header = reader.fieldnames
-        if actual_header != EXPECTED_HEADER:
-            print(f"ERROR: missing the following expected fields from input file '{csv_file}': {set(EXPECTED_HEADER) - set(actual_header)}", file=sys.stderr)
+        missing_fields = set(expected_header) - set(actual_header)
+        if missing_fields:
+            print(f"ERROR: missing the following expected fields from input file '{csv_file}': {missing_fields}", file=sys.stderr)
             sys.exit(1)
 
         for row in reader:
@@ -292,12 +377,15 @@ def validate_csv_file(csv_file):
         for row in reader:
             if row[LABEL] != row[PREFERRED_LABEL]:
                 label_mismatch_errors.append(f"{row[INTERNAL_ID]}: '{row[LABEL]}' != '{row[PREFERRED_LABEL]}'")
+            # if this isn't the TISSUE node, we need to make sure the parent resource uri/label pair matches exists in the file
+            # of course sometimes we are using the parent oncotree code intead (e.g. ALM)
             if row[ONCOTREE_CODE] != "TISSUE" and \
-                 (row[PARENT_LABEL] not in child_to_parent_labels \
-                  or row[PARENT_RESOURCE_URI] not in child_to_parent_resource_uris \
-                  or (child_uri_to_child_label[row[PARENT_RESOURCE_URI]] != row[PARENT_LABEL])): # check that the parent URI + label pair match the child URI + label pair
- 
+                parent_resource_uri_and_label_are_valid(row[PARENT_RESOURCE_URI], row[PARENT_LABEL], child_to_parent_resource_uris, child_uri_to_child_label, child_to_parent_labels):
                 parent_invalid_errors.append(f"{row[INTERNAL_ID]}: URI '{row[PARENT_RESOURCE_URI]}' and label '{row[PARENT_LABEL]}'")
+            elif row[ONCOTREE_CODE] == "TISSUE":
+                if row[PARENT_RESOURCE_URI] or row[PARENT_LABEL] or (PARENT_ONCOTREE_CODE in row and row[PARENT_ONCOTREE_CODE]):
+                    print(f"The 'TISSUE' node must not have any of these fields set: '{PARENT_RESOURCE_URI}', '{PARENT_LABEL}', '{PARENT_LABEL}' but at least one is in '{csv_file}'", file=sys.stderr)
+                    sys.exit(1)
 
     if label_mismatch_errors:
         print(f"ERROR: '{LABEL}' and '{PREFERRED_LABEL}' columns must be identical.  Mis-matched fields in '{csv_file}':")
@@ -312,6 +400,17 @@ def validate_csv_file(csv_file):
     if label_mismatch_errors or parent_invalid_errors:
         sys.exit(1)
 
+def get_internal_id_to_oncocodes():
+    response = requests.get(GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL) 
+    if response.status_code != 200:
+        print(f"Error: Failed to download GitHub raw resource uri to oncoode file. Status code was '{response.status_code}'.  Please confirm this is the correct url: '{GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL}'", file=sys.stderr)
+        sys.exit(1)
+    internal_id_to_oncocodes = {}
+    for row in response.text.splitlines():
+        fields = row.split()
+        if fields[1] == "hasCode":
+            internal_id_to_oncocodes[fields[0]] = fields[2]    
+    return internal_id_to_oncocodes
  
 def usage(parser, message):
     if message:
@@ -321,34 +420,47 @@ def usage(parser, message):
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-o", "--original-file", help = "original csv file from Graphite", required = True)
-    parser.add_argument("-m", "--modified-file", help = "modified csv file from user", required = True)
+    parser.add_argument("-o", "--original-file", help = f"Original csv file from Graphite. {HELP_FOR_FILE_FORMAT}", required = True)
+    parser.add_argument("-m", "--modified-file", help = f"Modified csv file from user.  This should be a modified copy of the original csv file from Graphite, with an additional column at the end called '{PARENT_ONCOTREE_CODE}'.", required = True)
     args = parser.parse_args()
 
     original_file = args.original_file
     modified_file = args.modified_file
 
     if not original_file or not modified_file: 
-        usage(parse, f"ERROR: missing file arguments, given original file '{original_file}' and modified file '{modified_file}'")
+        usage(parser, f"ERROR: missing file arguments, given original file '{original_file}' and modified file '{modified_file}'")
 
     if not os.path.isfile(original_file):
-        print(f"ERROR: cannot access original file {original_file}", file=sys.stderr)
+        usage(parser, f"ERROR: cannot access original file {original_file}")
         sys.exit(1)
 
     if not os.path.isfile(modified_file):
-        print(f"ERROR: cannot access modified file {modified_file}", file=sys.stderr)
+        usage(parser, f"ERROR: cannot access modified file {modified_file}")
         sys.exit(1)
     return original_file, modified_file
 
 def main():
     original_file, modified_file = get_args()
-    validate_csv_file(original_file)
-    validate_csv_file(modified_file)
+    validate_csv_file(original_file, EXPECTED_HEADER)
+    validate_csv_file(modified_file, EXPECTED_HEADER_MODIFIED_FILE)
     original_oncotree = get_oncotree(original_file)
     modified_oncotree = get_oncotree(modified_file)
+    internal_id_to_oncocodes = get_internal_id_to_oncocodes()
+    # get_all_precursors, get_all_revocations, get_resource_uri_to_internal_ids, get_oncotree_codes_to_resource_uris could be combined into one function
+    # we aren't reading the file over and over but this seems clearer
     precursor_id_to_internal_ids = get_all_precursors(modified_file)
     revocation_id_to_internal_ids = get_all_revocations(modified_file)
-    confirm_changes(original_oncotree, modified_oncotree, precursor_id_to_internal_ids, revocation_id_to_internal_ids)
+    original_resource_uri_to_internal_ids = get_resource_uri_to_internal_ids(original_file)
+    modified_resource_uri_to_internal_ids = get_resource_uri_to_internal_ids(modified_file)
+    oncotree_codes_to_internal_ids = get_oncotree_codes_to_internal_ids(modified_file)
+    confirm_changes(original_oncotree,
+                    modified_oncotree,
+                    precursor_id_to_internal_ids,
+                    revocation_id_to_internal_ids,
+                    original_resource_uri_to_internal_ids,
+                    modified_resource_uri_to_internal_ids,
+                    internal_id_to_oncocodes,
+                    oncotree_codes_to_internal_ids)
     output_rdf_file(modified_oncotree)
 
 if __name__ == '__main__':

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024 Memorial Sloan-Kettering Cancer Center.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  The software and
+# documentation provided hereunder is on an "as is" basis, and
+# Memorial Sloan-Kettering Cancer Center
+# has no obligations to provide maintenance, support,
+# updates, enhancements or modifications.  In no event shall
+# Memorial Sloan-Kettering Cancer Center
+# be liable to any party for direct, indirect, special,
+# incidental or consequential damages, including lost profits, arising
+# out of the use of this software and its documentation, even if
+# Memorial Sloan-Kettering Cancer Center
+# has been advised of the possibility of such damage.
+
+import argparse
+import csv
+from deepdiff import DeepDiff
+#from deepdiff import DeepSearch
+#from deepdiff import grep
+import os
+from pprint import pprint # TODO delete?
+import sys
+
+LABEL = "Primary Concept"
+RESOURCE_URI = "Resource URI"
+ONCOTREE_CODE = "notation (SKOS)"
+SCHEME_URI = "skos:inScheme URI"
+STATUS = "Status"
+INTERNAL_ID = "clinicalCasesSubset (OncoTree Tumor Type)"
+COLOR = "color (OncoTree Tumor Type)"
+MAIN_TYPE = "mainType (OncoTree Tumor Type)"
+PRECURSORS = "precursors (OncoTree Tumor Type)"
+PREFERRED_LABEL = "preferred label (SKOS)"
+REVOCATIONS = "revocations (OncoTree Tumor Type)"
+PARENT_RESOURCE_URI = "has broader (SKOS) URI"
+PARENT_LABEL = "has broader (SKOS)"
+# TODO explain exactly how to generate this file in Graphite here and in usage
+EXPECTED_HEADER = [RESOURCE_URI, LABEL, SCHEME_URI, STATUS, INTERNAL_ID, COLOR, MAIN_TYPE, ONCOTREE_CODE, PRECURSORS, PREFERRED_LABEL, REVOCATIONS, PARENT_RESOURCE_URI, PARENT_LABEL]
+
+def confirm_change(message):
+    print(f"\n{message}")
+    #answer = input("Enter [y]es if this change was intentional, [n]o if not: ")
+    answer = input("Enter [y]es if the changes were intentional, [n]o if not: ")
+    if answer.lower() in ["y","yes"]:
+        return True 
+    return False
+
+def construct_pretty_label_for_row(internal_id, code, label):
+    return f"{internal_id}: {label} ({code})"
+
+def confirm_changes(original_oncotree, modified_oncotree):
+    # get three sets of INTERNAL_IDs:
+    # 1) ones that have been removed
+    # 2) ones that are new
+    # 3) ones that are still there
+    # then handle each of the three sets
+    original_internal_id_set = set(original_oncotree.keys())
+    modified_internal_id_set = set(modified_oncotree.keys())
+
+    removed_internal_ids = original_internal_id_set - modified_internal_id_set
+    new_internal_ids = modified_internal_id_set - original_internal_id_set
+    in_both_internal_ids = original_internal_id_set & modified_internal_id_set
+
+    #print(removed_internal_ids)
+    #print(new_internal_ids)
+    #print(in_both_internal_ids)
+
+    all_changes_are_intentional = True
+
+    print("\nRemoved internal ids:")
+    if removed_internal_ids:
+        for internal_id in removed_internal_ids:
+            data = original_oncotree[internal_id]
+            pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
+            #message = f"Removed concept '{pretty_label}'"
+            #all_changes_are_intentional &= confirm_change(message)
+            print(f"\t{pretty_label}")
+    else:
+        print("\tNone")
+
+    print("\nNew internal ids:")
+    if new_internal_ids:
+        for internal_id in new_internal_ids:
+            data = modified_oncotree[internal_id]
+            pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
+            #message = f"A new concept has been added '{pretty_label}' - are you absolutely sure this is a new concept?"
+            #all_changes_are_intentional &= confirm_change(message)
+            print(f"\t{pretty_label}")
+    else:
+        print("\tNone")
+
+    # compare all deleted and new internal ids to see if any are really the same - TODO what counts as "the same"?
+    print("\nInternal ids that changed when no other data has changed ... are these really new concepts that cover different sets of cancer cases?")
+    found_id_change_with_no_data_change = False
+    for pair in {(x, y) for x in removed_internal_ids for y in new_internal_ids}:
+        #print(pair)
+        original_data = original_oncotree[pair[0]]
+        modified_data = modified_oncotree[pair[1]]
+        # TODO refactor and redo this section
+        diff = DeepDiff(original_data, modified_data, ignore_order=True)
+        #print(diff)
+        # remove the change we know about
+        diff['values_changed'] = {x : diff['values_changed'][x] for x in diff['values_changed'].keys() if x != f"root['{INTERNAL_ID}']"}
+        #print(diff)
+ 
+        if not diff['values_changed']: # TODO do we care about anything besides values_changed?
+            found_id_change_with_no_data_change = True
+            original_pretty_label = construct_pretty_label_for_row(original_data[INTERNAL_ID], original_data[ONCOTREE_CODE], original_data[LABEL])
+            modified_pretty_label = construct_pretty_label_for_row(modified_data[INTERNAL_ID], modified_data[ONCOTREE_CODE], modified_data[LABEL])
+            # TODO what changes really are important?  probably not color for example
+            #message = f"An internal id has changed from '{original_pretty_label}' to '{modified_pretty_label}' but all other data remains the same.  Is this really a new concept?"
+            #all_changes_are_intentional &= confirm_change(message)
+            print(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
+    if not found_id_change_with_no_data_change:
+        print("\tNone")
+
+    # now we look at all interal ids that are in both files, what has changed about the data?
+    code_change_messages = []
+    parent_change_messages = []
+    for internal_id in in_both_internal_ids:
+        original_data = original_oncotree[internal_id]
+        modified_data = modified_oncotree[internal_id]
+        original_pretty_label = construct_pretty_label_for_row(original_data[INTERNAL_ID], original_data[ONCOTREE_CODE], original_data[LABEL])
+        modified_pretty_label = construct_pretty_label_for_row(modified_data[INTERNAL_ID], modified_data[ONCOTREE_CODE], modified_data[LABEL])
+
+        # see what has changed 
+        diff = DeepDiff(original_data, modified_data, ignore_order=True)
+        if diff:
+            #print(diff)
+            if original_data[RESOURCE_URI] != modified_data[RESOURCE_URI]:
+                print(f"ERROR: Resource URI has changed for '{modified_pretty_label}', this is not allowed", file=sys.stderr)
+                sys.exit(1) 
+
+            if original_data[ONCOTREE_CODE] != modified_data[ONCOTREE_CODE]:
+                #message = f"The oncotree code/label has changed from '{original_pretty_label}' to '{modified_pretty_label}' but our internal id has not changed.  This is allowed as long as you are sure this covers the same set of cancer cases"
+                #all_changes_are_intentional &= confirm_change(message) 
+                code_change_messages.append(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
+
+            if original_data[PARENT_LABEL] != modified_data[PARENT_LABEL]:
+                parent_change_messages.append(f"\tchild: '{original_pretty_label}' parent: '{original_data[PARENT_LABEL]}' -> child: '{modified_pretty_label}' parent: '{modified_data[PARENT_LABEL]}'")
+      
+    print("\nOncotree code/label changes with no internal id change.  This is allowed as long as the new code/label covers the exact same set of cancer cases") 
+    if code_change_messages:
+        for message in code_change_messages:
+            print(message)
+    else:
+        print("\tNone")
+
+    print("\nParent change")
+    if parent_change_messages:
+        for message in parent_change_messages:
+            print(message)
+    else:
+        print("\tNone")
+ 
+        # TODO make sure two labels are always the same
+        # confirm that if a INTERNAL_ID has been deleted, it has either:
+        #  1) been made a revocation on an existing INTERNAL_ID - this is a concept that has been absorbed by another concept
+        #  2) been made a precusor for a new INTERNAL_ID - this is a concept that being replaced by a new concept
+        #  3) does not exist as anything anymore - is this allowed?
+    #if not all_changes_are_intentional:
+    if not confirm_change("\nPlease confirm that all of the above changes are intentional."):
+        print("ERROR: You  have said that not all changes are intentional.  Please correct your input file and run this script again.", file=sys.stderr)
+        sys.exit(2)
+
+def output_rdf_file(oncotree):
+    print("TODO: output RDF file")
+
+def get_oncotree(csv_file):
+    with open(csv_file, 'r', encoding='utf-8-sig') as file:
+        reader = csv.DictReader(file)
+        internal_id_to_data = {} 
+        for row in reader:
+            internal_id = row[INTERNAL_ID]
+            pretty_label = construct_pretty_label_for_row(internal_id, row[ONCOTREE_CODE], row[LABEL])
+            # TODO move to validation section
+            if row[STATUS] != 'Published':
+                print(f"WARNING: do not know what to do with node '{pretty_label}' which has a status of '{row[STATUS]}', excluding it from the output file")
+            internal_id_to_data[internal_id] = row
+        return internal_id_to_data
+
+def validate_csv_file(csv_file):
+    with open(csv_file, 'r', encoding='utf-8-sig') as file:
+        reader = csv.DictReader(file)
+        actual_header = reader.fieldnames
+        if actual_header != EXPECTED_HEADER:
+            print(f"ERROR: missing the following expected fields from input file '{csv_file}': {set(EXPECTED_HEADER) - set(actual_header)}", file=sys.stderr)
+            sys.exit(1)
+        # TODO add much more validation!
+        # TODO uniqueness:
+        #        * INTERNAL_ID
+        #        * ONCOTREE_CODE
+        #        * LABEL
+        #        * PREFERRED_LABEL
+        # validate all nodes have parent - that tree is still valid - and that we only include 'Published' nodes in this?
+        # TODO think about status - should we even be looking at it? why would the new data be 'Published'
+ 
+def usage(parser, message):
+    if message:
+        print(message, file=sys.stderr)
+    parser.print_help(file=sys.stderr)
+    sys.exit(1)
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--original-file", help = "original csv file from Graphite", required = True)
+    parser.add_argument("-m", "--modified-file", help = "modified csv file from user", required = True)
+    args = parser.parse_args()
+
+    original_file = args.original_file
+    modified_file = args.modified_file
+
+    if not original_file or not modified_file: 
+        usage(parse, f"ERROR: missing file arguments, given original file '{original_file}' and modified file '{modified_file}'")
+
+    if not os.path.isfile(original_file):
+        print(f"ERROR: cannot access original file {original_file}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isfile(modified_file):
+        print(f"ERROR: cannot access modified file {modified_file}", file=sys.stderr)
+        sys.exit(1)
+    return original_file, modified_file
+
+def main():
+    original_file, modified_file = get_args()
+    validate_csv_file(original_file)
+    validate_csv_file(modified_file)
+    original_oncotree = get_oncotree(original_file)
+    modified_oncotree = get_oncotree(modified_file)
+    confirm_changes(original_oncotree, modified_oncotree)
+    output_rdf_file(modified_oncotree)
+
+if __name__ == '__main__':
+   main()

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -433,7 +433,7 @@ def validate_and_confirm_changes(original_oncotree,
     if not confirm_change("\nPlease confirm that all of the above changes are intentional."):
         print("ERROR: You  have said that not all changes are intentional.  Please correct your input file and run this script again.", file=sys.stderr)
         sys.exit(2)
-    if not confirm_change("\nYou must manually delete all removed oncotree codes.  Please confirm you will do this."):
+    if not confirm_change("\nYou must manually delete all removed oncotree codes.  They should all be at the root level of the tree (at the tissue level).  They no longer have parents.  Please confirm you will manually delete these."):
         print("ERROR: You have not confirmed that you will delete all removed oncotree codes manually.  Please run this script again and confirm.", file=sys.stderr)
         sys.exit(2)
 
@@ -481,7 +481,7 @@ def field_is_required(field, field_name, internal_id, csv_file):
         print(f"'{field_name}' is a required field in '{csv_file}'. It is empty for '{internal_id}'", file=sys.stderr)
         sys.exit(1)
 
-def field_is_unique(field, field_name, column_set, internal_id, csv_file):
+def field_is_unique(field, field_name, column_set, csv_file):
     # don't count "" duplicates -- these should be dealt with in required field check
     if field != "" and field in column_set:
         print(f"{field_name} must be unique.  There is more than one record with '{field}' in '{csv_file}'", file=sys.stderr)
@@ -572,17 +572,14 @@ def validate_csv_file(csv_file,
             field_is_unique(row[graphite.CSV_RESOURCE_URI],
                             graphite.CSV_RESOURCE_URI,
                             resource_uri_set,
-                            row[graphite.CSV_INTERNAL_ID],
                             csv_file)
             field_is_unique(row[graphite.CSV_INTERNAL_ID],
                             graphite.CSV_INTERNAL_ID,
                             internal_id_set,
-                            row[graphite.CSV_ONCOTREE_CODE],
                             csv_file)
             field_is_unique(row[graphite.CSV_ONCOTREE_CODE],
                             graphite.CSV_ONCOTREE_CODE,
                             oncotree_code_set,
-                            row[graphite.CSV_INTERNAL_ID],
                             csv_file)
             resource_uri_set.add(row[graphite.CSV_RESOURCE_URI])
             internal_id_set.add(row[graphite.CSV_INTERNAL_ID])

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -129,14 +129,14 @@ def validate_and_display_new_internal_ids(new_internal_ids,
     else:
         print("\tNone")
 
-def display_precursor_or_revocation_of_list(precursor_id,
+def display_precursor_or_revocation_of_list(precursor_or_revocation_id,
                                             internal_ids_to_oncotree_codes,
-                                            precursor_id_to_internal_ids,
+                                            precursor_or_revocation_id_to_internal_ids,
                                             oncotree):
-    precursor_code = internal_ids_to_oncotree_codes[precursor_id] if precursor_id in internal_ids_to_oncotree_codes else "unknown"
-    print(f"\t\t'{precursor_id}' ('{precursor_code}')'")
-    precursor_of_set = precursor_id_to_internal_ids[precursor_id]
-    for internal_id in sorted(precursor_of_set):
+    oncotree_code = internal_ids_to_oncotree_codes[precursor_or_revocation_id] if precursor_or_revocation_id in internal_ids_to_oncotree_codes else "unknown"
+    print(f"\t\t'{precursor_or_revocation_id}' ('{oncotree_code}')'")
+    precursor_or_revocation_of_set = precursor_or_revocation_id_to_internal_ids[precursor_or_revocation_id]
+    for internal_id in sorted(precursor_or_revocation_of_set):
         data = oncotree[internal_id]
         pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID],
                                                       data[graphite.CSV_ONCOTREE_CODE],
@@ -160,57 +160,57 @@ def validate_precursors(modified_precursor_id_to_internal_ids,
                 print(f"Error: '{precursor_id}' ('{precursor_code}') is a precuror to '{','.join(modified_precursor_id_to_internal_ids[precursor_id])}' but '{precursor_id}' is still in this file as a current record", file=sys.stderr)
                 sys.exit(1)
 
-def display_precursors_or_revocations(original_precursor_id_to_internal_ids,
-                       modified_precursor_id_to_internal_ids,
+def display_precursors_or_revocations(original_precursor_or_revocation_id_to_internal_ids,
+                       modified_precursor_or_revocation_id_to_internal_ids,
                        original_oncotree,
                        modified_oncotree,
                        internal_ids_to_oncotree_codes,
                        modified_internal_id_set):
     # now see if there are any changes
-    original_precursor_ids = set(original_precursor_id_to_internal_ids.keys())
-    modified_precursor_ids = set(modified_precursor_id_to_internal_ids.keys())
-    removed_precursors = original_precursor_ids - modified_precursor_ids
-    new_precursors = modified_precursor_ids - original_precursor_ids
-    in_both_precursors = original_precursor_ids & modified_precursor_ids
-    changed_precursors = set({})
-    if in_both_precursors:
-        for precursor_id in in_both_precursors:
-            if (original_precursor_id_to_internal_ids[precursor_id] !=
-                    modified_precursor_id_to_internal_ids[precursor_id]):
-                changed_precursors.add(precursor_id)
+    original_precursor_or_revocation_ids = set(original_precursor_or_revocation_id_to_internal_ids.keys())
+    modified_precursor_or_revocation_ids = set(modified_precursor_or_revocation_id_to_internal_ids.keys())
+    removed_precursor_or_revocations = original_precursor_or_revocation_ids - modified_precursor_or_revocation_ids
+    new_precursor_or_revocations = modified_precursor_or_revocation_ids - original_precursor_or_revocation_ids
+    in_both_precursor_or_revocations = original_precursor_or_revocation_ids & modified_precursor_or_revocation_ids
+    changed_precursor_or_revocations = set({})
+    if in_both_precursor_or_revocations:
+        for precursor_or_revocation_id in in_both_precursor_or_revocations:
+            if (original_precursor_or_revocation_id_to_internal_ids[precursor_or_revocation_id] !=
+                    modified_precursor_or_revocation_id_to_internal_ids[precursor_or_revocation_id]):
+                changed_precursor_or_revocations.add(precursor_or_revocation_id)
 
-    if new_precursors or changed_precursors or removed_precursors:
-        if new_precursors:
+    if new_precursor_or_revocations or changed_precursor_or_revocations or removed_precursor_or_revocations:
+        if new_precursor_or_revocations:
             print("\tNew:")
-            for precursor_id in sorted(new_precursors):
-                display_precursor_or_revocation_of_list(precursor_id,
+            for precursor_or_revocation_id in sorted(new_precursor_or_revocations):
+                display_precursor_or_revocation_or_revocation_of_list(precursor_or_revocation_id,
                                                         internal_ids_to_oncotree_codes,
-                                                        modified_precursor_id_to_internal_ids,
+                                                        modified_precursor_or_revocation_id_to_internal_ids,
                                                         modified_oncotree)
 
-        if changed_precursors:
+        if changed_precursor_or_revocations:
             print("\tChanged:")
-            for precursor_id in sorted(changed_precursors):
-                original_precursor_of_set = set(original_precursor_id_to_internal_ids[precursor_id])
-                modified_precursor_of_set = set(modified_precursor_id_to_internal_ids[precursor_id])
+            for precursor_or_revocation_id in sorted(changed_precursor_or_revocations):
+                original_precursor_or_revocation_of_set = set(original_precursor_or_revocation_id_to_internal_ids[precursor_or_revocation_id])
+                modified_precursor_or_revocation_of_set = set(modified_precursor_or_revocation_id_to_internal_ids[precursor_or_revocation_id])
                 print("\t\tBefore")
-                display_precursor_or_revocation_of_list(precursor_id,
+                display_precursor_or_revocation_of_list(precursor_or_revocation_id,
                                                         internal_ids_to_oncotree_codes,
-                                                        original_precursor_id_to_internal_ids,
+                                                        original_precursor_or_revocation_id_to_internal_ids,
                                                         original_oncotree)
                 print("\t\tAfter")
-                display_precursor_or_revocation_of_list(precursor_id,
+                display_precursor_or_revocation_of_list(precursor_or_revocation_id,
                                                         internal_ids_to_oncotree_codes,
-                                                        modified_precursor_id_to_internal_ids,
+                                                        modified_precursor_or_revocation_id_to_internal_ids,
                                                         modified_oncotree)
 
-        if removed_precursors:
+        if removed_precursor_or_revocations:
             print("\tRemoved -- ARE YOU SURE YOU MEANT TO DO THIS?")
             # TODO is this an error?
-            for precursor_id in sorted(removed_precursors):
-                display_precursor_or_revocation_of_list(precursor_id,
+            for precursor_or_revocation_id in sorted(removed_precursor_or_revocations):
+                display_precursor_or_revocation_of_list(precursor_or_revocation_id,
                                           internal_ids_to_oncotree_codes,
-                                          original_precursor_id_to_internal_ids,
+                                          original_precursor_or_revocation_id_to_internal_ids,
                                           original_oncotree)
     else:
         print("\tNone")

--- a/scripts/validate_new_tree_and_output_rdf.py
+++ b/scripts/validate_new_tree_and_output_rdf.py
@@ -16,38 +16,27 @@
 # Memorial Sloan-Kettering Cancer Center
 # has been advised of the possibility of such damage.
 
-# TODO modified file will have extra column at end which will take onctoree codes as parent - require that 2 parent columns before it have been deleted, then I can generate UUID URIs and get the label
 # TODO maybe only show changes to precursors/revocations? instead of the whole history
-# TODO what to do about deletes? Maybe discuss with Rob? -- for now tell them to manually delete them
+# 1. validate
+# 2. say what has changed and confirm they are wanted
+# 3. generate rdf from the data
 
-import argparse
 from collections import defaultdict
-import csv
 from deepdiff import DeepDiff
+import argparse
+import csv
+import graphite
 import os
 import requests
 import sys
 
+COLUMN_NAME_YAML_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./graphite_csv_column_names.yaml")
 GITHUB_RESOURCE_URI_TO_ONCOCODE_MAPPING_FILE_URL = "https://raw.githubusercontent.com/cBioPortal/oncotree/refs/heads/master/resources/resource_uri_to_oncocode_mapping.txt"
 HELP_FOR_FILE_FORMAT = "In the Graphite 'Concept Manager' left sidebar 'Hierarchy' tab, select your oncotree version, then click on the 'Export' tab in the main panel.  For 'File Format' select 'CSV (Dynamic Property Columns)'. In the 'Include' section uncheck everything except 'Non-primary concept URI' and 'Status'.  In the 'Select Properties to Export' all fields in both 'OncoTree Tumor Type' and 'SKOS' should be selected."
-LABEL = "Primary Concept"
-RESOURCE_URI = "Resource URI"
-ONCOTREE_CODE = "notation (SKOS)"
-SCHEME_URI = "skos:inScheme URI"
-STATUS = "Status"
-INTERNAL_ID = "clinicalCasesSubset (OncoTree Tumor Type)"
-COLOR = "color (OncoTree Tumor Type)"
-MAIN_TYPE = "mainType (OncoTree Tumor Type)"
-PRECURSORS = "precursors (OncoTree Tumor Type)"
-PREFERRED_LABEL = "preferred label (SKOS)"
-REVOCATIONS = "revocations (OncoTree Tumor Type)"
-PARENT_RESOURCE_URI = "has broader (SKOS) URI"
-PARENT_LABEL = "has broader (SKOS)"
-PARENT_ONCOTREE_CODE = "parent oncotree code"
-EXPECTED_HEADER = [RESOURCE_URI, LABEL, SCHEME_URI, STATUS, INTERNAL_ID, COLOR, MAIN_TYPE, ONCOTREE_CODE, PRECURSORS, PREFERRED_LABEL, REVOCATIONS, PARENT_RESOURCE_URI, PARENT_LABEL]
-EXPECTED_HEADER_MODIFIED_FILE = EXPECTED_HEADER + [PARENT_ONCOTREE_CODE]
-REQUIRED_FIELDS = [LABEL, SCHEME_URI, STATUS, INTERNAL_ID, COLOR, MAIN_TYPE, ONCOTREE_CODE, PREFERRED_LABEL, PARENT_RESOURCE_URI, PARENT_LABEL]
-TISSUE_NODE_REQUIRED_FIELDS = [RESOURCE_URI, LABEL, SCHEME_URI, STATUS, INTERNAL_ID, ONCOTREE_CODE, PREFERRED_LABEL]
+EXPECTED_HEADER = [graphite.CSV_RESOURCE_URI, graphite.CSV_LABEL, graphite.CSV_SCHEME_URI, graphite.CSV_STATUS, graphite.CSV_INTERNAL_ID, graphite.CSV_COLOR, graphite.CSV_MAIN_TYPE, graphite.CSV_ONCOTREE_CODE, graphite.CSV_PRECURSORS, graphite.CSV_PREFERRED_LABEL, graphite.CSV_REVOCATIONS, graphite.CSV_PARENT_RESOURCE_URI, graphite.CSV_PARENT_LABEL]
+EXPECTED_HEADER_MODIFIED_FILE = EXPECTED_HEADER + [graphite.CSV_PARENT_ONCOTREE_CODE]
+REQUIRED_FIELDS = [graphite.CSV_LABEL, graphite.CSV_SCHEME_URI, graphite.CSV_STATUS, graphite.CSV_INTERNAL_ID, graphite.CSV_COLOR, graphite.CSV_MAIN_TYPE, graphite.CSV_ONCOTREE_CODE, graphite.CSV_PREFERRED_LABEL]
+TISSUE_NODE_REQUIRED_FIELDS = [graphite.CSV_RESOURCE_URI, graphite.CSV_LABEL, graphite.CSV_SCHEME_URI, graphite.CSV_STATUS, graphite.CSV_INTERNAL_ID, graphite.CSV_ONCOTREE_CODE, graphite.CSV_PREFERRED_LABEL]
 
 def confirm_change(message):
     print(f"\n{message}")
@@ -69,9 +58,9 @@ def get_all_precursors(csv_file):
         reader = csv.DictReader(file)
         precursor_id_to_internal_ids = defaultdict(set)
         for row in reader:
-            if row[PRECURSORS]:
-                for precursor_id in row[PRECURSORS].split(): # space separated
-                    precursor_id_to_internal_ids[precursor_id].add(row[INTERNAL_ID])
+            if row[graphite.CSV_PRECURSORS]:
+                for precursor_id in row[graphite.CSV_PRECURSORS].split(): # space separated
+                    precursor_id_to_internal_ids[precursor_id].add(row[graphite.CSV_INTERNAL_ID])
         return precursor_id_to_internal_ids
 
 # C01 + C02 + C03 -> C01
@@ -83,9 +72,9 @@ def get_all_revocations(csv_file):
         reader = csv.DictReader(file)
         revocation_id_to_internal_ids = defaultdict(set)
         for row in reader:
-            if row[REVOCATIONS]:
-                for revocation_id in row[REVOCATIONS].split(): # space separated
-                    revocation_id_to_internal_ids[revocation_id].add(row[INTERNAL_ID])
+            if row[graphite.CSV_REVOCATIONS]:
+                for revocation_id in row[graphite.CSV_REVOCATIONS].split(): # space separated
+                    revocation_id_to_internal_ids[revocation_id].add(row[graphite.CSV_INTERNAL_ID])
         return revocation_id_to_internal_ids   
 
 def get_resource_uri_to_internal_ids(csv_file):
@@ -93,7 +82,7 @@ def get_resource_uri_to_internal_ids(csv_file):
         reader = csv.DictReader(file)
         resource_uri_to_internal_ids = {}
         for row in reader:
-            resource_uri_to_internal_ids[row[RESOURCE_URI]] = row[INTERNAL_ID]
+            resource_uri_to_internal_ids[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_INTERNAL_ID]
         return resource_uri_to_internal_ids
 
 def get_oncotree_codes_to_internal_ids(csv_file):
@@ -101,19 +90,18 @@ def get_oncotree_codes_to_internal_ids(csv_file):
         reader = csv.DictReader(file)
         oncotree_codes_to_internal_ids = {}
         for row in reader:
-            oncotree_codes_to_internal_ids[row[ONCOTREE_CODE]] = row[INTERNAL_ID]
+            oncotree_codes_to_internal_ids[row[graphite.CSV_ONCOTREE_CODE]] = row[graphite.CSV_INTERNAL_ID]
         return oncotree_codes_to_internal_ids
 
 def get_parent_internal_id(child_internal_id, parent_resource_uri, parent_oncotree_code, oncotree_codes_to_internal_ids, resource_uri_to_internal_ids):
     if parent_oncotree_code:
-        # TODO validate parent_oncotree_codes in validate method?
         if parent_oncotree_code in oncotree_codes_to_internal_ids:    
             return oncotree_codes_to_internal_ids[parent_oncotree_code]
         else:
-            print(f"Error: '{PARENT_ONCOTREE_CODE}' '{parent_oncotree_code}' not found in modified file", file=sys.stderr)
+            print(f"Error: '{graphite.CSV_PARENT_ONCOTREE_CODE}' '{parent_oncotree_code}' not found in modified file", file=sys.stderr)
             sys.exit(1)
     if not parent_resource_uri:
-        print(f"Error: either '{PARENT_ONCOTREE_CODE}' or '{PARENT_RESOURCE_URI}' are required in the modified file, missing for '{child_internal_id}'", file=sys.stderr) 
+        print(f"Error: either '{graphite.CSV_PARENT_ONCOTREE_CODE}' or '{graphite.CSV_PARENT_RESOURCE_URI}' are required in the modified file, missing for '{child_internal_id}'", file=sys.stderr) 
         sys.exit(1)
     # we must have the parent_resource_uri instead
     return resource_uri_to_internal_ids[parent_resource_uri]
@@ -155,7 +143,7 @@ def confirm_changes(original_oncotree,
     if removed_internal_ids:
         for internal_id in sorted(removed_internal_ids):
             data = original_oncotree[internal_id]
-            pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
+            pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
             print(f"\t{pretty_label}")
         print(f"\n****** All removed Oncotree nodes must be manually deleted from Graphite")
     else:
@@ -165,15 +153,15 @@ def confirm_changes(original_oncotree,
     if new_internal_ids:
         for internal_id in sorted(new_internal_ids):
             data = modified_oncotree[internal_id]
-            pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
-            if data[RESOURCE_URI]:
+            pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
+            if data[graphite.CSV_RESOURCE_URI]:
                 # we could allow this but we would have to make sure the resource uri is new and is valid - so let's not
-                print(f"Error: you cannot have a '{RESOURCE_URI}' for a new oncotree node '{pretty_label}'", file=sys.stderr) 
+                print(f"Error: you cannot have a '{graphite.CSV_RESOURCE_URI}' for a new oncotree node '{pretty_label}'", file=sys.stderr) 
                 sys.exit(1)
             # show parent in "new" nodes
-            parent_internal_id = get_parent_internal_id(internal_id, data[PARENT_RESOURCE_URI], data[PARENT_ONCOTREE_CODE], oncotree_codes_to_internal_ids, modified_resource_uri_to_internal_ids)
+            parent_internal_id = get_parent_internal_id(internal_id, data[graphite.CSV_PARENT_RESOURCE_URI], data[graphite.CSV_PARENT_ONCOTREE_CODE], oncotree_codes_to_internal_ids, modified_resource_uri_to_internal_ids)
             parent_data = modified_oncotree[parent_internal_id]
-            parent_pretty_label = construct_pretty_label_for_row(parent_internal_id, parent_data[ONCOTREE_CODE], parent_data[LABEL])
+            parent_pretty_label = construct_pretty_label_for_row(parent_internal_id, parent_data[graphite.CSV_ONCOTREE_CODE], parent_data[graphite.CSV_LABEL])
             print(f"\t{pretty_label} has parent {parent_pretty_label}")
     else:
         print("\tNone")
@@ -189,7 +177,7 @@ def confirm_changes(original_oncotree,
             precursor_of_set = precursor_id_to_internal_ids[precursor_id]
             for internal_id in precursor_of_set:
                 data = modified_oncotree[internal_id]
-                pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
+                pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
                 print(f"\t'{precursor_id}' ('{precursor_code}') -> '{pretty_label}'")
     else:
         print("\tNone")
@@ -210,7 +198,7 @@ def confirm_changes(original_oncotree,
                     print(f"Error: '{revocation_id}' ('{revocation_code}') revokes '{internal_id}' but '{internal_id}' is a new concept. Only a pre-existing concept can revoke something", file=sys.stderr)
                     sys.exit(1)
                 data = modified_oncotree[internal_id]
-                pretty_label = construct_pretty_label_for_row(data[INTERNAL_ID], data[ONCOTREE_CODE], data[LABEL])
+                pretty_label = construct_pretty_label_for_row(data[graphite.CSV_INTERNAL_ID], data[graphite.CSV_ONCOTREE_CODE], data[graphite.CSV_LABEL])
                 print(f"\t'{revocation_id}' ('{revocation_code}') -> '{pretty_label}'")
     else:
         print("\tNone")
@@ -224,12 +212,12 @@ def confirm_changes(original_oncotree,
         modified_data = modified_oncotree[pair[1]]
         diff = DeepDiff(original_data, modified_data, ignore_order=True)
         # remove the change we know about (the internal id)
-        diff['values_changed'] = {x : diff['values_changed'][x] for x in diff['values_changed'].keys() if x != f"root['{INTERNAL_ID}']"}
+        diff['values_changed'] = {x : diff['values_changed'][x] for x in diff['values_changed'].keys() if x != f"root['{graphite.CSV_INTERNAL_ID}']"}
  
         if not diff['values_changed']: # TODO do we care about anything besides values_changed?
             found_id_change_with_no_data_change = True
-            original_pretty_label = construct_pretty_label_for_row(original_data[INTERNAL_ID], original_data[ONCOTREE_CODE], original_data[LABEL])
-            modified_pretty_label = construct_pretty_label_for_row(modified_data[INTERNAL_ID], modified_data[ONCOTREE_CODE], modified_data[LABEL])
+            original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID], original_data[graphite.CSV_ONCOTREE_CODE], original_data[graphite.CSV_LABEL])
+            modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID], modified_data[graphite.CSV_ONCOTREE_CODE], modified_data[graphite.CSV_LABEL])
             # TODO what changes really are important?  probably not color for example
             print(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
     if not found_id_change_with_no_data_change:
@@ -241,30 +229,30 @@ def confirm_changes(original_oncotree,
     for internal_id in in_both_internal_ids:
         original_data = original_oncotree[internal_id]
         modified_data = modified_oncotree[internal_id]
-        original_pretty_label = construct_pretty_label_for_row(original_data[INTERNAL_ID], original_data[ONCOTREE_CODE], original_data[LABEL])
-        modified_pretty_label = construct_pretty_label_for_row(modified_data[INTERNAL_ID], modified_data[ONCOTREE_CODE], modified_data[LABEL])
+        original_pretty_label = construct_pretty_label_for_row(original_data[graphite.CSV_INTERNAL_ID], original_data[graphite.CSV_ONCOTREE_CODE], original_data[graphite.CSV_LABEL])
+        modified_pretty_label = construct_pretty_label_for_row(modified_data[graphite.CSV_INTERNAL_ID], modified_data[graphite.CSV_ONCOTREE_CODE], modified_data[graphite.CSV_LABEL])
 
         # confirm we have resource uri in original file, we don't have to check modified file because we check if it has changed
-        if original_data[RESOURCE_URI].strip() == "":
+        if original_data[graphite.CSV_RESOURCE_URI].strip() == "":
             print(f"ERROR: Resource URI is required for all records in the original file but is missing for '{original_pretty_label}'", file=sys.stderr)
             sys.exit(1) 
 
-        if original_data[RESOURCE_URI] != modified_data[RESOURCE_URI]:
+        if original_data[graphite.CSV_RESOURCE_URI] != modified_data[graphite.CSV_RESOURCE_URI]:
             print(f"ERROR: Resource URI has changed for '{modified_pretty_label}', this is not allowed", file=sys.stderr)
             sys.exit(1) 
 
-        if original_data[ONCOTREE_CODE] != modified_data[ONCOTREE_CODE]:
+        if original_data[graphite.CSV_ONCOTREE_CODE] != modified_data[graphite.CSV_ONCOTREE_CODE]:
             code_change_messages.append(f"\t'{original_pretty_label}' -> '{modified_pretty_label}'")
 
         if internal_id != "ONC000001": # tissue has no parents
             # check if parent has changed
             # use oncotree codes (we will get either have the oncotree code, or will get it using the resource uri)
-            modified_parent_oncotree_code = modified_data[PARENT_ONCOTREE_CODE]
+            modified_parent_oncotree_code = modified_data[graphite.CSV_PARENT_ONCOTREE_CODE]
             if not modified_parent_oncotree_code: 
                 # then get the oncotree code using resource uri -> internal id -> oncotree code
                 modified_parent_internal_id = get_parent_internal_id(internal_id,
-                                                                     modified_data[PARENT_RESOURCE_URI],
-                                                                     modified_data[PARENT_ONCOTREE_CODE],
+                                                                     modified_data[graphite.CSV_PARENT_RESOURCE_URI],
+                                                                     modified_data[graphite.CSV_PARENT_ONCOTREE_CODE],
                                                                      oncotree_codes_to_internal_ids,
                                                                      modified_resource_uri_to_internal_ids)
                 modified_parent_oncotree_code = get_oncotree_code_from_internal_id(oncotree_codes_to_internal_ids, modified_parent_internal_id)
@@ -272,7 +260,7 @@ def confirm_changes(original_oncotree,
             # get the original parent oncotree code
             # in the original file we will have to look up the oncotree code using resource uri -> internal id -> oncotree code
             original_parent_internal_id = get_parent_internal_id(internal_id,
-                                                                 original_data[PARENT_RESOURCE_URI],
+                                                                 original_data[graphite.CSV_PARENT_RESOURCE_URI],
                                                                  None, # this file doesn't have a parent oncotree code column
                                                                  oncotree_codes_to_internal_ids,
                                                                  original_resource_uri_to_internal_ids)
@@ -299,20 +287,21 @@ def confirm_changes(original_oncotree,
         print("ERROR: You  have said that not all changes are intentional.  Please correct your input file and run this script again.", file=sys.stderr)
         sys.exit(2)
 
-def output_rdf_file(oncotree):
-    print("TODO: output RDF file")
+def output_rdf_file(oncotree, output_filename):
+    graphite.write_rdf(oncotree, output_filename)
 
 def get_oncotree(csv_file):
     with open(csv_file, 'r', encoding='utf-8-sig') as file:
         reader = csv.DictReader(file)
         internal_id_to_data = {} 
         for row in reader:
-            internal_id = row[INTERNAL_ID]
-            pretty_label = construct_pretty_label_for_row(internal_id, row[ONCOTREE_CODE], row[LABEL])
+            internal_id = row[graphite.CSV_INTERNAL_ID]
+            pretty_label = construct_pretty_label_for_row(internal_id, row[graphite.CSV_ONCOTREE_CODE], row[graphite.CSV_LABEL])
             # TODO move to validation section
-            if row[STATUS] != 'Published':
-                print(f"WARNING: do not know what to do with node '{pretty_label}' which has a status of '{row[STATUS]}', excluding it from the output file")
-            internal_id_to_data[internal_id] = row
+            if row[graphite.CSV_STATUS] != 'Published':
+                print(f"WARNING: do not know what to do with node '{pretty_label}' which has a status of '{row[graphite.CSV_STATUS]}', excluding it from the output file")
+            else:
+                internal_id_to_data[internal_id] = row
         return internal_id_to_data
 
 def field_is_required(field, field_name, internal_id, csv_file):
@@ -326,17 +315,32 @@ def field_is_unique(field, field_name, column_set, internal_id, csv_file):
         print(f"{field_name} must be unique.  There is more than one record with '{field}' in '{csv_file}'", file=sys.stderr)
         sys.exit(1)
 
+def parent_oncotree_code_is_valid(child_internal_id, parent_resource_uri, parent_oncotree_code, oncotree_codes_to_internal_ids, resource_uri_to_internal_ids):
+    # make sure that the code is valid
+    # make sure that if we have this code, is doesn't conflict with the parent resource uri (if we have that)
+    return not (parent_oncotree_code and \
+       parent_resource_uri and \
+       resource_uri_to_internal_ids[parent_resource_uri] != oncotree_codes_to_internal_ids[parent_oncotree_code])
+
 def parent_resource_uri_and_label_are_valid(parent_resource_uri, parent_label, child_to_parent_resource_uris, child_uri_to_child_label, child_to_parent_labels):
     return parent_label in child_to_parent_labels \
                   and parent_label in child_to_parent_resource_uris \
                   and (child_uri_to_child_label[parent_label] == parent_label)
 
+def parent_is_defined(oncotree_code, parent_resource_uri, parent_label, parent_oncotree_code):
+    if not (parent_oncotree_code or (parent_resource_uri and parent_label)):
+        print(f"'{oncotree_code}' does not have a parent defined either by the '{graphite.CSV_PARENT_ONCOTREE_CODE}' or both '{graphite.CSV_PARENT_RESOURCE_URI}' and '{graphite.CSV_PARENT_LABEL}'")
+        sys.exit(1)
+
 def validate_csv_file(csv_file, expected_header):
+    # TODO anything we need to use everywhere just get here
     # load all child->parent relationships
     # also check header and uniqueness and required values for some columns
     child_to_parent_resource_uris = {}
     child_to_parent_labels = {}
     child_uri_to_child_label = {} # make sure the parent uri + label match the child uri + label pair
+    oncotree_codes_to_internal_ids = {}
+    resource_uri_to_internal_ids = {}
 
     # these fields are required and must be unique
     resource_uri_set = set([])
@@ -352,48 +356,62 @@ def validate_csv_file(csv_file, expected_header):
 
         for row in reader:
             # save child->parent relationships
-            child_to_parent_resource_uris[row[RESOURCE_URI]] = row[PARENT_RESOURCE_URI] 
-            child_uri_to_child_label[row[RESOURCE_URI]] = row[LABEL]
-            child_to_parent_labels[row[LABEL]] = row[PARENT_LABEL] 
+            child_to_parent_resource_uris[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_PARENT_RESOURCE_URI] 
+            child_uri_to_child_label[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_LABEL]
+            child_to_parent_labels[row[graphite.CSV_LABEL]] = row[graphite.CSV_PARENT_LABEL] 
+            oncotree_codes_to_internal_ids[row[graphite.CSV_ONCOTREE_CODE]] = row[graphite.CSV_INTERNAL_ID]
+            resource_uri_to_internal_ids[row[graphite.CSV_RESOURCE_URI]] = row[graphite.CSV_INTERNAL_ID]
 
             # check all colunns are not empty
-            required_fields = TISSUE_NODE_REQUIRED_FIELDS if row[ONCOTREE_CODE] == "TISSUE" else REQUIRED_FIELDS
+            required_fields = TISSUE_NODE_REQUIRED_FIELDS if row[graphite.CSV_ONCOTREE_CODE] == "TISSUE" else REQUIRED_FIELDS
             for field in required_fields:
-                field_is_required(row[field], field, row[INTERNAL_ID], csv_file)  
+                field_is_required(row[field], field, row[graphite.CSV_INTERNAL_ID], csv_file)  
+           
+            if row[graphite.CSV_ONCOTREE_CODE] != 'TISSUE': 
+                parent_oncotree_code = "" if graphite.CSV_PARENT_ONCOTREE_CODE not in row else row[graphite.CSV_PARENT_ONCOTREE_CODE] 
+                parent_is_defined(row[graphite.CSV_ONCOTREE_CODE], row[graphite.CSV_PARENT_RESOURCE_URI], row[graphite.CSV_PARENT_LABEL], parent_oncotree_code)
 
             # check these columns are unique
-            field_is_unique(row[RESOURCE_URI], RESOURCE_URI, resource_uri_set, row[INTERNAL_ID], csv_file)
-            field_is_unique(row[INTERNAL_ID], INTERNAL_ID, internal_id_set, row[ONCOTREE_CODE], csv_file)
-            field_is_unique(row[ONCOTREE_CODE], ONCOTREE_CODE, oncotree_code_set, row[INTERNAL_ID], csv_file)
+            field_is_unique(row[graphite.CSV_RESOURCE_URI], graphite.CSV_RESOURCE_URI, resource_uri_set, row[graphite.CSV_INTERNAL_ID], csv_file)
+            field_is_unique(row[graphite.CSV_INTERNAL_ID], graphite.CSV_INTERNAL_ID, internal_id_set, row[graphite.CSV_ONCOTREE_CODE], csv_file)
+            field_is_unique(row[graphite.CSV_ONCOTREE_CODE], graphite.CSV_ONCOTREE_CODE, oncotree_code_set, row[graphite.CSV_INTERNAL_ID], csv_file)
 
-            resource_uri_set.add(row[RESOURCE_URI])
-            internal_id_set.add(row[INTERNAL_ID])
-            oncotree_code_set.add(row[ONCOTREE_CODE])
+            resource_uri_set.add(row[graphite.CSV_RESOURCE_URI])
+            internal_id_set.add(row[graphite.CSV_INTERNAL_ID])
+            oncotree_code_set.add(row[graphite.CSV_ONCOTREE_CODE])
 
+    # now read again once we have collected all ids etc. so we can look things up and make sure references are correct
     with open(csv_file, 'r', encoding='utf-8-sig') as file:
         reader = csv.DictReader(file)
         label_mismatch_errors = []
         parent_invalid_errors = []
         for row in reader:
-            if row[LABEL] != row[PREFERRED_LABEL]:
-                label_mismatch_errors.append(f"{row[INTERNAL_ID]}: '{row[LABEL]}' != '{row[PREFERRED_LABEL]}'")
+            if row[graphite.CSV_LABEL] != row[graphite.CSV_PREFERRED_LABEL]:
+                label_mismatch_errors.append(f"{row[graphite.CSV_INTERNAL_ID]}: '{row[graphite.CSV_LABEL]}' != '{row[graphite.CSV_PREFERRED_LABEL]}'")
             # if this isn't the TISSUE node, we need to make sure the parent resource uri/label pair matches exists in the file
             # of course sometimes we are using the parent oncotree code intead (e.g. ALM)
-            if row[ONCOTREE_CODE] != "TISSUE" and \
-                parent_resource_uri_and_label_are_valid(row[PARENT_RESOURCE_URI], row[PARENT_LABEL], child_to_parent_resource_uris, child_uri_to_child_label, child_to_parent_labels):
-                parent_invalid_errors.append(f"{row[INTERNAL_ID]}: URI '{row[PARENT_RESOURCE_URI]}' and label '{row[PARENT_LABEL]}'")
-            elif row[ONCOTREE_CODE] == "TISSUE":
-                if row[PARENT_RESOURCE_URI] or row[PARENT_LABEL] or (PARENT_ONCOTREE_CODE in row and row[PARENT_ONCOTREE_CODE]):
-                    print(f"The 'TISSUE' node must not have any of these fields set: '{PARENT_RESOURCE_URI}', '{PARENT_LABEL}', '{PARENT_LABEL}' but at least one is in '{csv_file}'", file=sys.stderr)
+            if row[graphite.CSV_ONCOTREE_CODE] != "TISSUE" and \
+                parent_resource_uri_and_label_are_valid(row[graphite.CSV_PARENT_RESOURCE_URI], row[graphite.CSV_PARENT_LABEL], child_to_parent_resource_uris, child_uri_to_child_label, child_to_parent_labels):
+                parent_invalid_errors.append(f"{row[graphite.CSV_INTERNAL_ID]}: URI '{row[graphite.CSV_PARENT_RESOURCE_URI]}' and label '{row[graphite.CSV_PARENT_LABEL]}'")
+            elif row[graphite.CSV_ONCOTREE_CODE] == "TISSUE":
+                if row[graphite.CSV_PARENT_RESOURCE_URI] or row[graphite.CSV_PARENT_LABEL] or (graphite.CSV_PARENT_ONCOTREE_CODE in row and row[graphite.CSV_PARENT_ONCOTREE_CODE]):
+                    print(f"The 'TISSUE' node must not have any of these fields set: '{graphite.CSV_PARENT_RESOURCE_URI}', '{graphite.CSV_PARENT_LABEL}', '{graphite.CSV_PARENT_LABEL}' but at least one is in '{csv_file}'", file=sys.stderr)
                     sys.exit(1)
+            elif graphite.CSV_PARENT_ONCOTREE_CODE in row \
+                and not parent_oncotree_code_is_valid(row[graphite.CSV_INTERNAL_ID],
+                        row[graphite.CSV_PARENT_RESOURCE_URI],
+                        row[graphite.CSV_PARENT_ONCOTREE_CODE],
+                        oncotree_codes_to_internal_ids,
+                        resource_uri_to_internal_ids):
+                parent_invalid_errors.append(f"Error: Child '{row[graphite.CSV_ONCOTREE_CODE]}' has parent oncotree code '{row[graphite.CSV_PARENT_ONCOTREE_CODE]}' which maps to internal id '{oncotree_codes_to_internal_ids[row[graphite.CSV_PARENT_ONCOTREE_CODE]]}' this is in conflict with the resource uri defined for the parent '{row[graphite.CSV_PARENT_RESOURCE_URI]}' which maps to internal id '{resource_uri_to_internal_ids[row[graphite.CSV_PARENT_RESOURCE_URI]]}'.  Which one is the parent?")
 
     if label_mismatch_errors:
-        print(f"ERROR: '{LABEL}' and '{PREFERRED_LABEL}' columns must be identical.  Mis-matched fields in '{csv_file}':")
+        print(f"ERROR: '{graphite.CSV_LABEL}' and '{graphite.CSV_PREFERRED_LABEL}' columns must be identical.  Mis-matched fields in '{csv_file}':")
         for message in label_mismatch_errors:
             print(f"\t{message}")
     
     if parent_invalid_errors:
-        print(f"ERROR: Invalid parents found in '{csv_file}'.  Either the parent '{PARENT_RESOURCE_URI}' or the parent '{PARENT_LABEL}' cannot be found in '{csv_file}', or the ('{PARENT_RESOURCE_URI}', '{PARENT_LABEL}') parent pair doesn't match the child  ('{RESOURCE_URI}', '{LABEL}') child pair.")
+        print(f"ERROR: Invalid parents found in '{csv_file}'.  Check that the oncotree code is valid if it was entered, or if you are using the resource uri/label pair, that they are defined in '{csv_file}'")
         for message in parent_invalid_errors:
             print(f"\t{message}")
 
@@ -421,11 +439,13 @@ def usage(parser, message):
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--original-file", help = f"Original csv file from Graphite. {HELP_FOR_FILE_FORMAT}", required = True)
-    parser.add_argument("-m", "--modified-file", help = f"Modified csv file from user.  This should be a modified copy of the original csv file from Graphite, with an additional column at the end called '{PARENT_ONCOTREE_CODE}'.", required = True)
+    parser.add_argument("-m", "--modified-file", help = f"Modified csv file from user.  This should be a modified copy of the original csv file from Graphite, with an additional column at the end called '{graphite.CSV_PARENT_ONCOTREE_CODE}'.", required = True)
+    parser.add_argument("-t", "--output-file", help = f"Generated rdf file to be uploaded to Graphite.", required = True)
     args = parser.parse_args()
 
     original_file = args.original_file
     modified_file = args.modified_file
+    output_file = args.output_file
 
     if not original_file or not modified_file: 
         usage(parser, f"ERROR: missing file arguments, given original file '{original_file}' and modified file '{modified_file}'")
@@ -434,13 +454,18 @@ def get_args():
         usage(parser, f"ERROR: cannot access original file {original_file}")
         sys.exit(1)
 
+    if os.path.isfile(output_file):
+        usage(parser, f"ERROR: {output_file} already exists and will be overwritten")
+        sys.exit(1)
+
     if not os.path.isfile(modified_file):
         usage(parser, f"ERROR: cannot access modified file {modified_file}")
         sys.exit(1)
-    return original_file, modified_file
+    
+    return original_file, modified_file, output_file
 
 def main():
-    original_file, modified_file = get_args()
+    original_file, modified_file, output_file = get_args()
     validate_csv_file(original_file, EXPECTED_HEADER)
     validate_csv_file(modified_file, EXPECTED_HEADER_MODIFIED_FILE)
     original_oncotree = get_oncotree(original_file)
@@ -461,7 +486,7 @@ def main():
                     modified_resource_uri_to_internal_ids,
                     internal_id_to_oncocodes,
                     oncotree_codes_to_internal_ids)
-    output_rdf_file(modified_oncotree)
+    output_rdf_file(modified_oncotree, output_file)
 
 if __name__ == '__main__':
    main()


### PR DESCRIPTION
Given two CSV files (one oncotree downloaded from Graphite, the second the same file modified with any changes needed to the tree) this will output an RDF file to be uploaded to Graphite.  Any nodes that need removing from Graphite must be removed manually.  The script will validate the changes and also output a description of them and will ask the user to confirm that all changes are intentional.  It will remind them to manually delete any oncotree nodes that have been removed.

An example run from the script looks like this:
```
% ./validate_new_tree_and_output_rdf.py -o original.csv -m modified.csv -t to_upload.rdf

Removed internal ids:
	ONC000251: Cervical Adenoid Basal Carcinoma (CABC)
	ONC000612: Uterine Perivascular Epithelioid Cell Tumor (UPECOMA)
	ONC000733: B-Lymphoblastic Leukemia/Lymphoma, NOS (BLLNOS)

New internal ids:
	ONC000612X: Uterine Perivascular Epithelioid Cell Tumor (UPECOMA) has parent ONC000607: Uterine Sarcoma/Mesenchymal (USARC)
	ONC000999: My new cancer type (TEST) has parent ONC000001: Tissue (TISSUE)
	ONC001000: Another new type (TEST2) has parent ONC000016: Gallbladder Cancer (GBC)

Precursors:
	None

Revocations:
	Removed -- ARE YOU SURE YOU MEANT TO DO THIS?
		'ONC000376' ('PTCL')'
			'ONC000379: Peripheral T-Cell lymphoma, NOS (PTCL)'

Oncotree code/label changes with no internal id change.  This is allowed as long as the new code/label covers the exact same set of cancer cases
	'ONC000293: Eye (EYE)' -> 'ONC000293: Eye (EYEX)'

Parent change
	child: 'ONC000294: Retinoblastoma (RBL)' parent: 'EYE' -> child: 'ONC000294: Retinoblastoma (RBL)' parent: 'OM'


Please confirm that all of the above changes are intentional.
Enter [y]es, [n]o if not: 
```

To see the help:
```
wilson@LSKI4221:scripts% ./validate_new_tree_and_output_rdf.py -h
usage: validate_new_tree_and_output_rdf.py [-h] -o ORIGINAL_FILE -m MODIFIED_FILE -t OUTPUT_FILE

options:
  -h, --help            show this help message and exit
  -o ORIGINAL_FILE, --original-file ORIGINAL_FILE
                        Original csv file from Graphite. In the Graphite 'Concept Manager' left sidebar 'Hierarchy' tab, select your oncotree version, then click on the
                        'Export' tab in the main panel. For 'File Format' select 'CSV (Dynamic Property Columns)'. In the 'Include' section uncheck everything except 'Non-
                        primary concept URI' and 'Status'. In the 'Select Properties to Export' all fields in both 'OncoTree Tumor Type' and 'SKOS' should be selected.
  -m MODIFIED_FILE, --modified-file MODIFIED_FILE
                        Modified csv file from user. This should be a modified copy of the original csv file from Graphite, with an additional column at the end called
                        'parent oncotree code'.
  -t OUTPUT_FILE, --output-file OUTPUT_FILE
                        Generated rdf file to be uploaded to Graphite.
```