### PR TITLE
fix: oncoTree rendering multiple times

### DIFF
--- a/web/src/main/javascript/src/pages/Home/Home.tsx
+++ b/web/src/main/javascript/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import OncoTree, { OncoTreeNode, ToolbarAction } from "@oncokb/oncotree";
 import ToolbarItem from "../../components/Toolbar/ToolbarItem";
 
@@ -17,21 +17,22 @@ export default function Home({
 }: IHomeProps) {
   const treeContainerRef = useRef<HTMLDivElement>(null);
   const dataRef = useRef<typeof oncoTreeData | undefined>();
-
+  const [isInitialized, setIsInitialized] = useState(false);
   useEffect(() => {
     const versionChanged = dataRef.current !== oncoTreeData;
 
-    if (treeContainerRef.current && versionChanged) {
+    if (treeContainerRef.current && versionChanged && !isInitialized) {
       if (treeContainerRef.current.children.length > 0) {
         treeContainerRef.current.innerHTML = "";
       }
 
       const oncoTree = new OncoTree(TREE_CONTAINER_ID, oncoTreeData);
       onOncoTreeInit(oncoTree);
+      setIsInitialized(true);
     }
 
     dataRef.current = oncoTreeData;
-  }, [oncoTreeData, onOncoTreeInit]);
+  }, [oncoTreeData, onOncoTreeInit, isInitialized]);
 
   return (
     <>


### PR DESCRIPTION
At home page the OncoTree was rendering multiple time over reaload

[Screencast from 25-01-25 02:40:50 PM IST.webm](https://github.com/user-attachments/assets/b7bd3494-eb5f-4a99-93ad-d1c95dbcf645)


It was due to the useEffect triggering multiple times. So once the tree is initialise it shouldn't be triggered again.
Video after making changes.

[Screencast from 25-01-25 02:41:23 PM IST.webm](https://github.com/user-attachments/assets/8f16b4eb-80e7-466f-b58a-313cf7d5bc97)
